### PR TITLE
GitHub Actions CI: Discover typos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,11 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run Tests
         run: cd Pulse && swift build
+      - name: Discover typos
+        run: |
+          python3 -m pip install --upgrade pip
+          python3 -m pip install codespell
+          codespell --ignore-words-list="hart,inout,msdos,sur" --skip="./Pulse/.build/*"
 #  tvos-latest:
 #    name: Unit Tests (tvOS 14.2, Xcode 12.2)
 #    runs-on: macOS-latest

--- a/Pulse/Sources/PulseCore/ZIPFoundation/Archive.swift
+++ b/Pulse/Sources/PulseCore/ZIPFoundation/Archive.swift
@@ -115,7 +115,7 @@ final class Archive: Sequence {
 
     /// Initializes a new ZIP `Archive`.
     ///
-    /// You can use this initalizer to create new archive files or to read and update existing ones.
+    /// You can use this initializer to create new archive files or to read and update existing ones.
     /// The `mode` parameter indicates the intended usage of the archive: `.read`, `.create` or `.update`.
     /// - Parameters:
     ///   - url: File URL to the receivers backing file.

--- a/Pulse/Sources/PulseUI/Extensions/Foundation+Extensions.swift
+++ b/Pulse/Sources/PulseUI/Extensions/Foundation+Extensions.swift
@@ -24,7 +24,7 @@ func prettifyJSON(_ data: Data) -> String {
 }
 
 extension String {
-    /// Finds all occurences of the given string
+    /// Finds all occurrences of the given string
     func ranges(of substring: String, options: String.CompareOptions = []) -> [Range<String.Index>] {
         var index = startIndex
         var ranges = [Range<String.Index>]()

--- a/Pulse/Sources/PulseUI/Services/JSONPrinter.swift
+++ b/Pulse/Sources/PulseUI/Services/JSONPrinter.swift
@@ -53,7 +53,7 @@ private func getClass(for element: JSONElement) -> String {
 @available(iOS 13, tvOS 14.0, *)
 final class JSONPrinter {
     private let renderer: JSONRenderer
-    private var indention = 0
+    private var indentation = 0
 
     init(renderer: JSONRenderer) {
         self.renderer = renderer
@@ -76,9 +76,9 @@ final class JSONPrinter {
                 indent()
                 append("  \"\(key)\"", .key)
                 append(": ", .punctuation)
-                indention += 2
+                indentation += 2
                 print(json: object[key]!, isFree: false)
-                indention -= 2
+                indentation -= 2
                 if key != keys.last {
                     append(",", .punctuation)
                 }
@@ -91,7 +91,7 @@ final class JSONPrinter {
         case let array as Array<Any>:
             if array.contains(where: { $0 is [String: Any] }) {
                 append("[\n", .punctuation)
-                indention += 2
+                indentation += 2
                 for index in array.indices {
                     print(json: array[index], isFree: true)
                     if index < array.endIndex - 1 {
@@ -99,7 +99,7 @@ final class JSONPrinter {
                     }
                     newline()
                 }
-                indention -= 2
+                indentation -= 2
                 indent()
                 append("]", .punctuation)
             } else {
@@ -128,7 +128,7 @@ final class JSONPrinter {
     }
 
     func indent() {
-        renderer.indent(count: indention)
+        renderer.indent(count: indentation)
     }
 
     func newline() {

--- a/Pulse/Sources/PulseUI/Services/LoggerSync.swift
+++ b/Pulse/Sources/PulseUI/Services/LoggerSync.swift
@@ -51,7 +51,7 @@ private final class SessionDelegate: NSObject, WCSessionDelegate {
     }
 
     func sessionDidDeactivate(_ session: WCSession) {
-        debugPrint("WCSession did deactive")
+        debugPrint("WCSession did deactivate")
     }
     #endif
 

--- a/Pulse/Sources/PulseUI/Views/NotList.swift
+++ b/Pulse/Sources/PulseUI/Views/NotList.swift
@@ -28,7 +28,7 @@ final class NotListViewModel<Element: NotListIdentifiable>: ObservableObject {
     }
 }
 
-// Becuase SwiftUI List is pretty broken on macOS https://kean.blog/post/not-list
+// Because SwiftUI List is pretty broken on macOS https://kean.blog/post/not-list
 struct NotList<Element: NotListIdentifiable>: NSViewRepresentable {
     @ObservedObject var model: NotListViewModel<Element>
 


### PR DESCRIPTION
As discussed in #23 

Fixes typos in five .swift files.

Runs `codespell --ignore-words-list="hart,inout,msdos,sur" --skip="./Pulse/.build/*"` on every change.