### PR TITLE
Make swizzled URLSession init method signature match the origin init method to avoid unexpected crash

### DIFF
--- a/Pulse/Sources/PulseCore/URLSessionProxyDelegate.swift
+++ b/Pulse/Sources/PulseCore/URLSessionProxyDelegate.swift
@@ -13,7 +13,7 @@ public final class URLSessionProxyDelegate: NSObject, URLSessionTaskDelegate, UR
 
     /// - parameter logger: By default, creates a logger with `LoggerStore.default`.
     /// - parameter delegate: The "actual" session delegate.
-    public init(logger: NetworkLogger = .init(), delegate: URLSessionDelegate) {
+    public init(logger: NetworkLogger = .init(), delegate: URLSessionDelegate?) {
         self.actualDelegate = delegate
         self.taskDelegate = delegate as? URLSessionTaskDelegate
         self.interceptedSelectors = [
@@ -70,7 +70,7 @@ public final class URLSessionProxyDelegate: NSObject, URLSessionTaskDelegate, UR
 // MARK: - Automatic Registration
 
 private extension URLSession {
-    @objc class func pulse_init(configuration: URLSessionConfiguration, delegate: URLSessionDelegate, delegateQueue: OperationQueue?) -> URLSession {
+    @objc class func pulse_init(configuration: URLSessionConfiguration, delegate: URLSessionDelegate?, delegateQueue: OperationQueue?) -> URLSession {
         let delegate = URLSessionProxyDelegate(logger: sharedLogger, delegate: delegate)
         return self.pulse_init(configuration: configuration, delegate: delegate, delegateQueue: delegateQueue)
     }


### PR DESCRIPTION
Hi @kean, first of all, thank you for creating such a cool library! 

After the integration using the swizzling approach, we've noticed that our app started to crash occasionally. Apparently, the crash reason was related to the fact that `pust_init` URLSession method signature didn't really match the original `init` method. The swizzled method had `delegate` defined as non-optional whereas the original method has it defined as optional. Since we're swizzling the `init` method for every instance of `URLSession` created after a call of `URLSession.enableAutomaticRegistration()` it may lead to a crash when `nil` passed as a `delegate` value. 

This PR shall also fix #29