### PR TITLE
Fix empty request.httpBody causing PulseUI to not show it on the summary view

### DIFF
--- a/Pulse/Sources/PulseCore/LoggerStore.swift
+++ b/Pulse/Sources/PulseCore/LoggerStore.swift
@@ -573,8 +573,8 @@ fileprivate extension URLRequest {
 		var bodyStreamData = Data()
 		
 		while bodyStream.hasBytesAvailable {
-			let readDat = bodyStream.read(buffer, maxLength: bufferSize)
-			bodyStreamData.append(buffer, count: readDat)
+			let readData = bodyStream.read(buffer, maxLength: bufferSize)
+			bodyStreamData.append(buffer, count: readData)
 		}
 		
 		return bodyStreamData


### PR DESCRIPTION
# What's changed
Minor change that sets the `httpBodyStreamData` if `httpBody` is nil to the `NetworkLoggerRequestSummary`.


## Note
Wasn't sure if I should even make this PR or not, but ye here it is.
And if anyone has a better solution, or I was doing something wrong, since I was not seeing request body in the `PulseUI`, please let me know.