### PR TITLE
Add remote logging for clients running macOS 11 and higher

### DIFF
--- a/Pulse/Sources/PulseCore/LoggerStoreInfo.swift
+++ b/Pulse/Sources/PulseCore/LoggerStoreInfo.swift
@@ -120,4 +120,9 @@ extension LoggerStoreInfo.DeviceInfo {
         )
     }
 }
+
+func getDeviceId() -> UUID? {
+    return nil
+}
+
 #endif

--- a/Pulse/Sources/PulseCore/RemoteLogger/RemoteLogger-Connection.swift
+++ b/Pulse/Sources/PulseCore/RemoteLogger/RemoteLogger-Connection.swift
@@ -5,13 +5,13 @@
 import Foundation
 import Network
 
-@available(iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, *)
 public protocol RemoteLoggerConnectionDelegate: AnyObject {
     func connection(_ connection: RemoteLogger.Connection, didChangeState newState: NWConnection.State)
     func connection(_ connection: RemoteLogger.Connection, didReceiveEvent event: RemoteLogger.Connection.Event)
 }
 
-@available(iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, *)
 extension RemoteLogger {
     public final class Connection {
         private let connection: NWConnection
@@ -118,7 +118,7 @@ extension RemoteLogger {
 
 // MARK: Helpers
 
-@available(iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, *)
 private extension RemoteLogger {
     static func encode(code: UInt8, body: Data) throws -> Data {
         guard body.count < UInt32.max else {

--- a/Pulse/Sources/PulseCore/RemoteLogger/RemoteLogger-Protocol.swift
+++ b/Pulse/Sources/PulseCore/RemoteLogger/RemoteLogger-Protocol.swift
@@ -5,7 +5,7 @@
 import Foundation
 import Network
 
-@available(iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, *)
 extension RemoteLogger {
     enum PacketCode: UInt8 {
         case clientHello = 0 // PacketClientHello
@@ -117,7 +117,7 @@ extension RemoteLogger {
     }
 }
 
-@available(iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, *)
 extension RemoteLogger.Connection {
     func send(code: RemoteLogger.PacketCode, data: Data, _ completion: ((NWError?) -> Void)? = nil) {
         send(code: code.rawValue, data: data, completion)

--- a/Pulse/Sources/PulseCore/RemoteLogger/RemoteLogger-Store.swift
+++ b/Pulse/Sources/PulseCore/RemoteLogger/RemoteLogger-Store.swift
@@ -8,7 +8,7 @@ import Combine
 import SwiftUI
 
 // These methods are not designed to be used publicly.
-@available(iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, *)
 extension RemoteLogger {
     public static func store(_ message: LoggerStore.Message, into store: LoggerStore) {
         store.storeMessage(message)

--- a/Pulse/Sources/PulseCore/RemoteLogger/RemoteLogger.swift
+++ b/Pulse/Sources/PulseCore/RemoteLogger/RemoteLogger.swift
@@ -7,13 +7,13 @@ import Network
 import Combine
 import SwiftUI
 
-#if os(iOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(tvOS) || os(watchOS) || os(macOS)
 /// Connects to the remote server and sends logs remotely. In the current version,
 /// a server is a Pulse Pro app for macOS).
 ///
 /// The logger is thread-safe. The updates to the `Published` properties will
 /// be delivered on a background queue.
-@available(iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, *)
 public final class RemoteLogger: RemoteLoggerConnectionDelegate {
     private(set) public var store: LoggerStore?
     
@@ -410,7 +410,7 @@ private func getFallbackDeviceId() -> UUID {
         return UUID(uuidString: value) ?? UUID()
     }
     let id = UUID()
-    UserDefaults.standard.set(id, forKey: key)
+    UserDefaults.standard.set(id.uuidString, forKey: key)
     return id
 }
 
@@ -426,7 +426,7 @@ private extension NWBrowser.Result {
     }
 }
 
-@available(iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, *)
 extension RemoteLogger.ConnectionState {
     public var description: String {
         switch self {
@@ -442,7 +442,7 @@ public enum RemoteLogger {
 }
 #endif
 
-@available(iOS 14.0, tvOS 14.0, watchOS 7.0, *)
+@available(iOS 14.0, tvOS 14.0, watchOS 7.0, macOS 11.0, *)
 extension RemoteLogger {
     public static let serviceType = "_pulse._tcp"
 }


### PR DESCRIPTION
While remote logging is great for iOS devices/simulators, it is also useful for macOS. This change enables it for macOS 11.