### PR TITLE
Change logs folder name to avoid confusing it with proper logs document

### DIFF
--- a/Pulse/Sources/PulseCore/Extensions.swift
+++ b/Pulse/Sources/PulseCore/Extensions.swift
@@ -26,7 +26,7 @@ extension FileManager {
 extension URL {
     static var temp: URL {
         let url = Files.temporaryDirectory
-            .appendingDirectory("com.github.kean.pulse")
+            .appendingDirectory("Pulse")
         Files.createDirectoryIfNeeded(at: url)
         return url
     }
@@ -34,7 +34,7 @@ extension URL {
     static var logs: URL {
         var url = Files.urls(for: .libraryDirectory, in: .userDomainMask).first?
             .appendingDirectory("Logs")
-            .appendingDirectory("com.github.kean.pulse")  ?? URL(fileURLWithPath: "/dev/null")
+            .appendingDirectory("Pulse")  ?? URL(fileURLWithPath: "/dev/null")
         if !Files.createDirectoryIfNeeded(at: url) {
             var resourceValues = URLResourceValues()
             resourceValues.isExcludedFromBackup = true

--- a/Pulse/Sources/PulseUI/Mocks/MockStore.swift
+++ b/Pulse/Sources/PulseUI/Mocks/MockStore.swift
@@ -23,7 +23,7 @@ extension LoggerStore {
 }
 
 private func makeMockStore() -> LoggerStore {
-    let rootURL = FileManager.default.temporaryDirectory.appendingPathComponent("com.github.kean.pulse-ui-demo")
+    let rootURL = FileManager.default.temporaryDirectory.appendingPathComponent("Pulse-ui-demo")
     try? FileManager.default.removeItem(at: rootURL) // TODO: cleanup
     try? FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true, attributes: nil)
 


### PR DESCRIPTION
Fixes #47

Tried to run tests with Xcode, they crash in one same place. `LoggerStoreTests`, `testRemoveAllMessages`, `storeMessage` function

Tried to run tests with script, script misses `destinations` input, somehow.

It would be cool to have some guide on contributing, or at least on running known scripts in the process.