### PR TITLE
Remove explicit foreground color on filter icon

### DIFF
--- a/Sources/PulseUI/Features/Console/ConsoleView-ios.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleView-ios.swift
@@ -87,7 +87,6 @@ private struct QuickFiltersView: View {
                     isShowingFilters = true
                 }) {
                     Image(systemName: "line.horizontal.3.decrease.circle")
-                        .foregroundColor(Color.blue)
                 }.buttonStyle(PlainButtonStyle())
             }
             ConsoleQuickFiltersView(filters: model.quickFilters)


### PR DESCRIPTION
Not sure if this is by design, but it might be more desirable to let it use the tint color.