### PR TITLE
Fixed multi-threading crash when copying a store

### DIFF
--- a/Sources/PulseCore/LoggerStore.swift
+++ b/Sources/PulseCore/LoggerStore.swift
@@ -641,11 +641,11 @@ extension LoggerStore {
     }
 
     private func messageCount() throws -> Int {
-        try container.viewContext.fetch(LoggerMessageEntity.fetchRequest()).count
+        try backgroundContext.fetch(LoggerMessageEntity.fetchRequest()).count
     }
 
     private func networkRequestsCount() throws -> Int {
-        try container.viewContext.fetch(LoggerNetworkRequestEntity.fetchRequest()).count
+        try backgroundContext.fetch(LoggerNetworkRequestEntity.fetchRequest()).count
     }
 }
 


### PR DESCRIPTION
When the store is a .directory type and `public func copy(to targetURL: URL) throws` is called, the copy in that method is performed on the backgroundContext. In the `private func copy(to targetURL: URL, tempURL: URL, blobs: BlobStore)` that is called, the manifest is created using `LoggerStoreInfo` which calls `try messageCount()` and `try networkRequestsCount()`. Both of these methods do their fetch using `container.viewContext` which is a different thread leading to a crash.

You can verify the crash by using the `com.apple.CoreData.ConcurrencyDebug 1` runtime flag (see [https://oleb.net/blog/2014/06/core-data-concurrency-debugging/](Core Data Concurrency Debugging) and then exporting the LoggerStore.

By getting the counts on the same thread, this crash is eliminated.