### PR TITLE
Add predicate to removeAll

### DIFF
--- a/Sources/PulseCore/LoggerStore.swift
+++ b/Sources/PulseCore/LoggerStore.swift
@@ -541,14 +541,16 @@ extension LoggerStore {
     }
 
     /// Removes all of the previously recorded messages.
-    public func removeAll() {
-        backgroundContext.perform(_removeAll)
+    public func removeAll(_ predicate: NSPredicate? = nil) {
+        backgroundContext.perform { self._removeAll(predicate) }
     }
 
-    private func _removeAll() {
+    private func _removeAll(_ predicate: NSPredicate? = nil) {
         switch document {
         case .directory(let blobs):
-            try? deleteMessages(fetchRequest: LoggerMessageEntity.fetchRequest())
+            let fetch = LoggerMessageEntity.fetchRequest()
+            if let predicate = predicate { fetch.predicate = predicate }
+            try? deleteMessages(fetchRequest: fetch)
             blobs.removeAll()
         case .file, .empty:
             break // Do nothing, readonly


### PR DESCRIPTION
Hi @kean,

I have an issue I need to clean the log from private information before sharing it. I don't see a way to do this so I did this PR to try to implement it or at least provide an idea of how to do it.

I want to be able to remove all LoggerMessageEntity that contain certain pieces of information.