### PR TITLE
fix retain cycle.

### DIFF
--- a/Sources/PulseCore/URLSessionProxyDelegate.swift
+++ b/Sources/PulseCore/URLSessionProxyDelegate.swift
@@ -6,8 +6,8 @@ import Foundation
 
 /// Automates URLSession request tracking.
 public final class URLSessionProxyDelegate: NSObject, URLSessionTaskDelegate, URLSessionDataDelegate {
-    private var actualDelegate: URLSessionDelegate?
-    private var taskDelegate: URLSessionTaskDelegate?
+    weak private var actualDelegate: URLSessionDelegate?
+    weak private var taskDelegate: URLSessionTaskDelegate?
     private let interceptedSelectors: Set<Selector>
     private let logger: NetworkLogger
 


### PR DESCRIPTION
Captured by Xcode's `Debug Memory Graph` and it is causing some duplicated logs.