### PR TITLE
More menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 
 ### PulseUI
 
+- Add new context menu to Console and Network screen with many quick actions that were previously hidden in Settings, e.g. "Remove Logs". Settings were removed from the primary tabs `MainView`. With this change, for apps that don't use `MainView` and integrate individual tabs into their own debug menus, integration became significantly eaier because both Console and Network screens are fully self-sufficient.
+- Add "Report Issue" button.
+- Rework Settings screen on iOS. Add a few new options: `lineLimit`.
 - Add public `StoreDetailsView`
 - Fix an issue where search in text viewer would occasionally stop highlighting the results
 - Add a missing public `InsightsView` initializer 

--- a/Sources/PulseUI/Extensions/SwiftUIExtensions.swift
+++ b/Sources/PulseUI/Extensions/SwiftUIExtensions.swift
@@ -206,6 +206,19 @@ extension Backport {
 #endif
     }
 
+    @ViewBuilder
+    func fullScreenCover<Content: View>(isPresented: Binding<Bool>, @ViewBuilder _ content: @escaping () -> Content) -> some View {
+#if os(iOS)
+        if #available(iOS 14.0, *) {
+            self.content.fullScreenCover(isPresented: isPresented, content: content)
+        } else {
+            self.content
+        }
+#else
+        self.content
+#endif
+    }
+
     enum PresentationDetent {
         case large
         case medium

--- a/Sources/PulseUI/Extensions/SwiftUIExtensions.swift
+++ b/Sources/PulseUI/Extensions/SwiftUIExtensions.swift
@@ -186,4 +186,28 @@ extension Backport {
         self.content
 #endif
     }
+
+    @ViewBuilder
+    func presentationDetents(_ detents: Set<PresentationDetent>) -> some View {
+#if os(iOS)
+        if #available(iOS 16.0, *) {
+            let detents = detents.map { (detent)-> SwiftUI.PresentationDetent in
+                switch detent {
+                case .large: return .large
+                case .medium: return .medium
+                }
+            }
+            self.content.presentationDetents(Set(detents))
+        } else {
+            self.content
+        }
+#else
+        self.content
+#endif
+    }
+
+    enum PresentationDetent {
+        case large
+        case medium
+    }
 }

--- a/Sources/PulseUI/Features/Console/ConsoleContextMenu-ios.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleContextMenu-ios.swift
@@ -27,7 +27,7 @@ struct ConsoleContextMenu: View {
                 }
                 if !store.isArchive {
                     Button(action: { isDocumentBrowserPresented = true }) {
-                        Label("Browse Stores", systemImage: "doc")
+                        Label("Browse Saved Logs", systemImage: "folder")
                     }
                 }
             }
@@ -40,11 +40,11 @@ struct ConsoleContextMenu: View {
                 Section {
                     if #available(iOS 15.0, *) {
                         Button(role: .destructive, action: buttonRemoveAllTapped) {
-                            Label("Remove Message", systemImage: "trash")
+                            Label("Remove Logs", systemImage: "trash")
                         }
                     } else {
                         Button(action: buttonRemoveAllTapped) {
-                            Label("Remove Message", systemImage: "trash")
+                            Label("Remove Logs", systemImage: "trash")
                         }
                     }
                 }

--- a/Sources/PulseUI/Features/Console/ConsoleContextMenu-ios.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleContextMenu-ios.swift
@@ -1,0 +1,113 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020–2022 Alexander Grebenyuk (github.com/kean).
+
+import SwiftUI
+import CoreData
+import Pulse
+import Combine
+
+#if os(iOS)
+
+import UniformTypeIdentifiers
+
+@available(iOS 14.0, *)
+struct ConsoleContextMenu: View {
+    let store: LoggerStore
+
+    @State private var isShowingSettings = false
+    @State private var isShowingStoreInfo = false
+    @State private var isDocumentBrowserPresented = false
+
+    var body: some View {
+        Menu {
+            Section {
+                Button(action: { isShowingStoreInfo = true }) {
+                    Label("Store Info", systemImage: "info.circle")
+                }
+                if !store.isArchive {
+                    Button(action: { isDocumentBrowserPresented = true }) {
+                        Label("Browse Stores", systemImage: "doc")
+                    }
+                }
+            }
+            Section {
+                Button(action: { isShowingSettings = true }) {
+                    Label("Settings", systemImage: "gear")
+                }
+            }
+            if !store.isArchive {
+                Section {
+                    if #available(iOS 15.0, *) {
+                        Button(role: .destructive, action: buttonRemoveAllTapped) {
+                            Label("Remove Message", systemImage: "trash")
+                        }
+                    } else {
+                        Button(action: buttonRemoveAllTapped) {
+                            Label("Remove Message", systemImage: "trash")
+                        }
+                    }
+                }
+            }
+        } label: {
+            Image(systemName: "ellipsis.circle")
+        }
+        .sheet(isPresented: $isShowingSettings) {
+            NavigationView {
+                SettingsView(store: store)
+                    .navigationBarItems(trailing: Button(action: { isShowingSettings = false }) {
+                        Text("Done")
+                    })
+            }
+        }
+        .sheet(isPresented: $isShowingStoreInfo) {
+            NavigationView {
+                StoreDetailsView(source: .store(store))
+                    .navigationBarItems(trailing: Button(action: { isShowingStoreInfo = false }) {
+                        Text("Done")
+                    })
+            }
+        }
+        .fullScreenCover(isPresented: $isDocumentBrowserPresented) {
+            DocumentBrowser()
+        }
+    }
+
+    private func buttonRemoveAllTapped() {
+        store.removeAll()
+
+#if os(iOS)
+        runHapticFeedback(.success)
+        ToastView {
+            HStack {
+                Image(systemName: "trash")
+                Text("All messages removed")
+            }
+        }.show()
+#endif
+    }
+}
+
+@available(iOS 14.0, *)
+private struct DocumentBrowser: UIViewControllerRepresentable {
+    func makeUIViewController(context: Context) -> DocumentBrowserViewController {
+        DocumentBrowserViewController(forOpeningContentTypes: [UTType(filenameExtension: "pulse")].compactMap { $0 })
+    }
+
+    func updateUIViewController(_ uiViewController: DocumentBrowserViewController, context: Context) {
+
+    }
+}
+
+#if DEBUG
+@available(iOS 14.0, *)
+struct ConsoleContextMenu_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            ConsoleContextMenu(store: .mock)
+        }
+    }
+}
+#endif
+
+#endif

--- a/Sources/PulseUI/Features/Console/ConsoleContextMenu-ios.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleContextMenu-ios.swift
@@ -64,6 +64,8 @@ struct ConsoleContextMenu: View {
         .sheet(isPresented: $isShowingSettings) {
             NavigationView {
                 SettingsView(store: store)
+                    .navigationTitle("Settings")
+                    .navigationBarTitleDisplayMode(.inline)
                     .navigationBarItems(trailing: Button(action: { isShowingSettings = false }) {
                         Text("Done")
                     })

--- a/Sources/PulseUI/Features/Console/ConsoleContextMenu-ios.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleContextMenu-ios.swift
@@ -27,7 +27,7 @@ struct ConsoleContextMenu: View {
                 }
                 if !store.isArchive {
                     Button(action: { isDocumentBrowserPresented = true }) {
-                        Label("Browse Saved Logs", systemImage: "folder")
+                        Label("Browse Logs", systemImage: "folder")
                     }
                 }
             }

--- a/Sources/PulseUI/Features/Console/ConsoleContextMenu-ios.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleContextMenu-ios.swift
@@ -50,10 +50,13 @@ struct ConsoleContextMenu: View {
                 }
             }
             Section {
-                Button(action: buttonSponsorTapped) {
-                    Label("Sponsor", systemImage: "link")
-                }
                 Text("Pulse is funded by the community contributions")
+                Button(action: buttonSponsorTapped) {
+                    Label("Sponsor", systemImage: "heart")
+                }
+                Button(action: buttonSendFeedbackTapped) {
+                    Label("Report Issue", systemImage: "envelope")
+                }
             }
         } label: {
             Image(systemName: "ellipsis.circle")
@@ -92,9 +95,12 @@ struct ConsoleContextMenu: View {
     }
 
     private func buttonSponsorTapped() {
-        guard let url = URL(string: "https://github.com/sponsors/kean") else {
-            return
-        }
+        guard let url = URL(string: "https://github.com/sponsors/kean") else { return }
+        UIApplication.shared.open(url)
+    }
+
+    private func buttonSendFeedbackTapped() {
+        guard let url = URL(string: "https://github.com/kean/Pulse/issu") else { return }
         UIApplication.shared.open(url)
     }
 }

--- a/Sources/PulseUI/Features/Console/ConsoleContextMenu-ios.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleContextMenu-ios.swift
@@ -49,6 +49,12 @@ struct ConsoleContextMenu: View {
                     }
                 }
             }
+            Section {
+                Button(action: buttonSponsorTapped) {
+                    Label("Sponsor", systemImage: "link")
+                }
+                Text("Pulse is funded by the community contributions")
+            }
         } label: {
             Image(systemName: "ellipsis.circle")
         }
@@ -76,7 +82,6 @@ struct ConsoleContextMenu: View {
     private func buttonRemoveAllTapped() {
         store.removeAll()
 
-#if os(iOS)
         runHapticFeedback(.success)
         ToastView {
             HStack {
@@ -84,7 +89,13 @@ struct ConsoleContextMenu: View {
                 Text("All messages removed")
             }
         }.show()
-#endif
+    }
+
+    private func buttonSponsorTapped() {
+        guard let url = URL(string: "https://github.com/sponsors/kean") else {
+            return
+        }
+        UIApplication.shared.open(url)
     }
 }
 
@@ -104,7 +115,10 @@ private struct DocumentBrowser: UIViewControllerRepresentable {
 struct ConsoleContextMenu_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            ConsoleContextMenu(store: .mock)
+            VStack {
+                ConsoleContextMenu(store: .mock)
+                Spacer()
+            }
         }
     }
 }

--- a/Sources/PulseUI/Features/Console/ConsoleMessageTableCell.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleMessageTableCell.swift
@@ -39,7 +39,6 @@ final class ConsoleMessageTableCell: UITableViewCell, UIContextMenuInteractionDe
 
         title.font = .preferredFont(forTextStyle: .caption1)
         details.font = .systemFont(ofSize: 15)
-        details.numberOfLines = 4
 
         let interaction = UIContextMenuInteraction(delegate: self)
         self.addInteraction(interaction)
@@ -48,6 +47,7 @@ final class ConsoleMessageTableCell: UITableViewCell, UIContextMenuInteractionDe
     func display(_ viewModel: ConsoleMessageViewModel) {
         self.viewModel = viewModel
 
+        details.numberOfLines = ConsoleSettings.shared.lineLimit
         title.attributedText = viewModel.attributedTitle
         details.text = viewModel.text
         details.textColor = viewModel.textColor2

--- a/Sources/PulseUI/Features/Console/ConsoleMessageView.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleMessageView.swift
@@ -9,7 +9,7 @@ import Combine
 
 struct ConsoleMessageView: View {
     let viewModel: ConsoleMessageViewModel
-    
+
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
             HStack(alignment: .firstTextBaseline) {
@@ -59,7 +59,6 @@ struct ConsoleMessageView: View {
         Text(viewModel.text)
             .font(fonts.body)
             .foregroundColor(viewModel.textColor)
-            .lineLimit(4)
     }
     
     private struct Fonts {

--- a/Sources/PulseUI/Features/Console/ConsoleNetworkRequestTableCell.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleNetworkRequestTableCell.swift
@@ -48,7 +48,6 @@ final class ConsoleNetworkRequestTableCell: UITableViewCell, UIContextMenuIntera
         title.textColor = .secondaryLabel
 
         details.font = .systemFont(ofSize: 15)
-        details.numberOfLines = 4
 
         let interaction = UIContextMenuInteraction(delegate: self)
         self.addInteraction(interaction)
@@ -97,6 +96,7 @@ final class ConsoleNetworkRequestTableCell: UITableViewCell, UIContextMenuIntera
         title.text = viewModel.fullTitle
 
         if !onlyTitle {
+            details.numberOfLines = ConsoleSettings.shared.lineLimit
             badge.fillColor = viewModel.uiBadgeColor
             details.text = viewModel.text
             accessory.textLabel.text = viewModel.time

--- a/Sources/PulseUI/Features/Console/ConsoleTableView-ios.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleTableView-ios.swift
@@ -71,7 +71,7 @@ final class ConsoleTableViewController: UITableViewController {
     private let viewModel: ConsoleTableViewModel
     private var entities: [NSManagedObject] = []
     private var entityViewModels: [NSManagedObjectID: AnyObject] = [:]
-    private var cancellable: AnyCancellable?
+    private var cancellables: [AnyCancellable] = []
 
     var onSelected: ((NSManagedObject) -> Void)?
 
@@ -91,12 +91,16 @@ final class ConsoleTableViewController: UITableViewController {
         tableView.register(ConsoleNetworkRequestTableCell.self, forCellReuseIdentifier: "ConsoleNetworkRequestTableCell")
 
         tableView.separatorInset = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 0)
+
+        ConsoleSettings.shared.$lineLimit.sink { [weak self] _ in
+            self?.tableView.reloadData()
+        }.store(in: &cancellables)
     }
 
     private func bind(_ viewModel: ConsoleTableViewModel) {
-        cancellable = viewModel.$entities.sink { [weak self] entities in
+        viewModel.$entities.sink { [weak self] entities in
             self?.display(entities)
-        }
+        }.store(in: &cancellables)
     }
 
     private var isFirstDisplay = true

--- a/Sources/PulseUI/Features/Console/ConsoleView-ios.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleView-ios.swift
@@ -12,6 +12,7 @@ import Combine
 public struct ConsoleView: View {
     @ObservedObject var viewModel: ConsoleViewModel
     @State private var isSharing = false
+    @State private var isShowingSettings = false
 
     public init(store: LoggerStore = .shared) {
         self.viewModel = ConsoleViewModel(store: store)
@@ -31,7 +32,12 @@ public struct ConsoleView: View {
                 leading: viewModel.onDismiss.map {
                     Button(action: $0) { Image(systemName: "xmark") }
                 },
-                trailing: ShareButton { isSharing = true }
+                trailing: HStack {
+                    ShareButton { isSharing = true }
+                    if #available(iOS 14.0, *) {
+                        contextMenu
+                    }
+                }
             )
             .sheet(isPresented: $isSharing) {
                 if #available(iOS 14.0, *) {
@@ -42,6 +48,25 @@ public struct ConsoleView: View {
                     ShareView(ShareItems(messages: viewModel.store))
                 }
             }
+            .sheet(isPresented: $isShowingSettings) {
+                NavigationView {
+                    SettingsView(store: viewModel.store)
+                        .navigationBarItems(trailing: Button(action: { isShowingSettings = false }) {
+                            Text("Done")
+                        })
+                }
+            }
+    }
+
+    @available(iOS 14.0, *)
+    private var contextMenu: some View {
+        Menu {
+            Button(action: { isShowingSettings = true }) {
+                SwiftUI.Label("Settings", systemImage: "gear")
+            }
+        } label: {
+            Image(systemName: "ellipsis.circle")
+        }
     }
 
     private var contentView: some View {

--- a/Sources/PulseUI/Features/Console/ConsoleView-ios.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleView-ios.swift
@@ -37,7 +37,7 @@ public struct ConsoleView: View {
                 if #available(iOS 14.0, *) {
                     NavigationView {
                         ShareStoreView(store: viewModel.store, isPresented: $isSharing)
-                    }
+                    }.backport.presentationDetents([.medium])
                 } else {
                     ShareView(ShareItems(messages: viewModel.store))
                 }

--- a/Sources/PulseUI/Features/Console/ConsoleView-ios.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleView-ios.swift
@@ -61,8 +61,17 @@ public struct ConsoleView: View {
     @available(iOS 14.0, *)
     private var contextMenu: some View {
         Menu {
-            Button(action: { isShowingSettings = true }) {
-                SwiftUI.Label("Settings", systemImage: "gear")
+            Section {
+                Button(action: { isShowingSettings = true }) {
+                    SwiftUI.Label("Settings", systemImage: "gear")
+                }
+            }
+            if !viewModel.store.isArchive {
+                Section {
+                    Button(action: buttonRemoveAllTapped) {
+                        SwiftUI.Label("Remove Message", systemImage: "trash")
+                    }
+                }
             }
         } label: {
             Image(systemName: "ellipsis.circle")
@@ -83,6 +92,22 @@ public struct ConsoleView: View {
         if viewModel.entities.isEmpty {
             PlaceholderView.make(viewModel: viewModel)
         }
+    }
+
+    // MARK: Helpers
+
+    private func buttonRemoveAllTapped() {
+        viewModel.store.removeAll()
+
+#if os(iOS)
+        runHapticFeedback(.success)
+        ToastView {
+            HStack {
+                Image(systemName: "trash")
+                Text("All messages removed")
+            }
+        }.show()
+#endif
     }
 }
 

--- a/Sources/PulseUI/Features/Console/ConsoleView-ios.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleView-ios.swift
@@ -9,14 +9,9 @@ import Combine
 
 #if os(iOS)
 
-import UniformTypeIdentifiers
-
 public struct ConsoleView: View {
     @ObservedObject var viewModel: ConsoleViewModel
     @State private var isSharing = false
-    @State private var isShowingSettings = false
-    @State private var isShowingStoreInfo = false
-    @State private var isDocumentBrowserPresented = false
 
     public init(store: LoggerStore = .shared) {
         self.viewModel = ConsoleViewModel(store: store)
@@ -39,7 +34,7 @@ public struct ConsoleView: View {
                 trailing: HStack {
                     ShareButton { isSharing = true }
                     if #available(iOS 14.0, *) {
-                        contextMenu
+                        ConsoleContextMenu(store: viewModel.store)
                     }
                 }
             )
@@ -52,65 +47,6 @@ public struct ConsoleView: View {
                     ShareView(ShareItems(messages: viewModel.store))
                 }
             }
-            .sheet(isPresented: $isShowingSettings) {
-                NavigationView {
-                    SettingsView(store: viewModel.store)
-                        .navigationBarItems(trailing: Button(action: { isShowingSettings = false }) {
-                            Text("Done")
-                        })
-                }
-            }
-            .sheet(isPresented: $isShowingStoreInfo) {
-                if #available(iOS 14.0, *) {
-                    NavigationView {
-                        StoreDetailsView(source: .store(viewModel.store))
-                            .navigationBarItems(trailing: Button(action: { isShowingStoreInfo = false }) {
-                                Text("Done")
-                            })
-                    }
-                }
-            }
-            .backport.fullScreenCover(isPresented: $isDocumentBrowserPresented) {
-                if #available(iOS 14.0, *) {
-                    DocumentBrowser()
-                }
-            }
-    }
-
-    @available(iOS 14.0, *)
-    private var contextMenu: some View {
-        Menu {
-            Section {
-                Button(action: { isShowingStoreInfo = true }) {
-                    Label("Store Info", systemImage: "info.circle")
-                }
-                if !viewModel.store.isArchive {
-                    Button(action: { isDocumentBrowserPresented = true }) {
-                        Label("Browse Stores", systemImage: "doc")
-                    }
-                }
-            }
-            Section {
-                Button(action: { isShowingSettings = true }) {
-                    Label("Settings", systemImage: "gear")
-                }
-            }
-            if !viewModel.store.isArchive {
-                Section {
-                    if #available(iOS 15.0, *) {
-                        Button(role: .destructive, action: buttonRemoveAllTapped) {
-                            Label("Remove Message", systemImage: "trash")
-                        }
-                    } else {
-                        Button(action: buttonRemoveAllTapped) {
-                            Label("Remove Message", systemImage: "trash")
-                        }
-                    }
-                }
-            }
-        } label: {
-            Image(systemName: "ellipsis.circle")
-        }
     }
 
     private var contentView: some View {
@@ -127,22 +63,6 @@ public struct ConsoleView: View {
         if viewModel.entities.isEmpty {
             PlaceholderView.make(viewModel: viewModel)
         }
-    }
-
-    // MARK: Helpers
-
-    private func buttonRemoveAllTapped() {
-        viewModel.store.removeAll()
-
-#if os(iOS)
-        runHapticFeedback(.success)
-        ToastView {
-            HStack {
-                Image(systemName: "trash")
-                Text("All messages removed")
-            }
-        }.show()
-#endif
     }
 }
 
@@ -173,17 +93,6 @@ private struct ConsoleToolbarView: View {
                 ConsoleFiltersView(viewModel: viewModel.searchCriteria, isPresented: $isShowingFilters)
             }
         }
-    }
-}
-
-@available(iOS 14.0, *)
-private struct DocumentBrowser: UIViewControllerRepresentable {
-    func makeUIViewController(context: Context) -> DocumentBrowserViewController {
-        DocumentBrowserViewController(forOpeningContentTypes: [UTType(filenameExtension: "pulse")].compactMap { $0 })
-    }
-
-    func updateUIViewController(_ uiViewController: DocumentBrowserViewController, context: Context) {
-
     }
 }
 

--- a/Sources/PulseUI/Features/Main/MainViewModel-ios.swift
+++ b/Sources/PulseUI/Features/Main/MainViewModel-ios.swift
@@ -46,10 +46,9 @@ final class MainViewModel: ObservableObject {
 #endif
 
         self.settings = SettingsViewModel(store: store)
-        self.settings.onDismiss = onDismiss
 
 #if os(iOS)
-        self.items = [.console, .network, .pins, !store.isArchive ? .insights : nil, .settings]
+        self.items = [.console, .network, .pins, !store.isArchive ? .insights : nil]
             .compactMap { $0 }
 #elseif os(tvOS)
         self.items = [.console, .network, .settings]

--- a/Sources/PulseUI/Features/Main/MainViewModel-ios.swift
+++ b/Sources/PulseUI/Features/Main/MainViewModel-ios.swift
@@ -116,7 +116,11 @@ extension MainViewModel {
             InsightsView(viewModel: insights)
 #endif
         case .settings:
+#if os(iOS)
+            EmptyView()
+#else
             SettingsView(viewModel: settings)
+#endif
         default: fatalError()
         }
     }

--- a/Sources/PulseUI/Features/Network/NetworkView.swift
+++ b/Sources/PulseUI/Features/Network/NetworkView.swift
@@ -13,7 +13,7 @@ public struct NetworkView: View {
     @ObservedObject var viewModel: NetworkViewModel
 
     @State private var isShowingFilters = false
-    @State private var isShowingShareSheet = false
+    @State private var isSharing = false
     @Environment(\.colorScheme) private var colorScheme: ColorScheme
 
     public init(store: LoggerStore = .shared) {
@@ -36,7 +36,24 @@ public struct NetworkView: View {
         .onDisappear(perform: viewModel.onDisappear)
         .overlay(tableOverlay)
         .navigationBarTitle(Text("Network"))
-        .navigationBarItems(leading: navigationBarTrailingItems)
+        .navigationBarItems(
+            leading: navigationBarTrailingItems,
+            trailing: HStack {
+                ShareButton { isSharing = true }
+                if #available(iOS 14.0, *) {
+                    ConsoleContextMenu(store: viewModel.store)
+                }
+            }
+        )
+        .sheet(isPresented: $isSharing) {
+            if #available(iOS 14.0, *) {
+                NavigationView {
+                    ShareStoreView(store: viewModel.store, isPresented: $isSharing)
+                }.backport.presentationDetents([.medium])
+            } else {
+                ShareView(ShareItems(messages: viewModel.store))
+            }
+        }
     }
 
     @ViewBuilder

--- a/Sources/PulseUI/Features/Network/NetworkViewModel.swift
+++ b/Sources/PulseUI/Features/Network/NetworkViewModel.swift
@@ -24,7 +24,7 @@ final class NetworkViewModel: NSObject, NSFetchedResultsControllerDelegate, Obse
 
     var onDismiss: (() -> Void)?
 
-    private let store: LoggerStore
+    let store: LoggerStore
     private let controller: NSFetchedResultsController<NetworkTaskEntity>
     private var isActive = false
     private var latestSessionId: UUID?

--- a/Sources/PulseUI/Features/Settings/ConsoleSettings.swift
+++ b/Sources/PulseUI/Features/Settings/ConsoleSettings.swift
@@ -1,0 +1,31 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020–2022 Alexander Grebenyuk (github.com/kean).
+
+import SwiftUI
+import Pulse
+import Combine
+
+// TODO: Switch to AppStorage on iOS 14
+public final class ConsoleSettings: ObservableObject {
+    public static let shared = ConsoleSettings()
+
+    @Published public var lineLimit = 4
+
+    private var cancellables: [AnyCancellable] = []
+
+    init() {
+        lineLimit = UserDefaults.standard.integer(forKey: .lineLimitKey)
+        if lineLimit == 0 { lineLimit = 4 }
+
+        $lineLimit.sink {
+            UserDefaults.standard.set($0, forKey: .lineLimitKey) }
+        .store(in: &cancellables)
+    }
+}
+
+private extension String {
+    static let lineLimitKey = "\(keyPrefix)console-line-limit"
+}
+
+private let keyPrefix = "com-github-com-kean-pulse__"

--- a/Sources/PulseUI/Features/Settings/SettingsView-ios.swift
+++ b/Sources/PulseUI/Features/Settings/SettingsView-ios.swift
@@ -1,0 +1,50 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020–2022 Alexander Grebenyuk (github.com/kean).
+
+import SwiftUI
+import Pulse
+
+#if os(iOS)
+import UniformTypeIdentifiers
+
+@available(iOS 14.0, *)
+public struct SettingsView: View {
+    @ObservedObject var viewModel: SettingsViewModel
+    @ObservedObject var settings: ConsoleSettings = .shared
+
+    public init(store: LoggerStore = .shared) {
+        // TODO: Fix ownership
+        self.viewModel = SettingsViewModel(store: store)
+    }
+
+    init(viewModel: SettingsViewModel) {
+        self.viewModel = viewModel
+    }
+
+    public var body: some View {
+        Form {
+            Section {
+                Stepper("Line Limit: \(settings.lineLimit)", value: $settings.lineLimit, in: 1...20)
+            }
+            if viewModel.isRemoteLoggingAvailable {
+                Section {
+                    RemoteLoggerSettingsView(viewModel: .shared)
+                }
+            }
+        }
+    }
+}
+
+#if DEBUG
+@available(iOS 14.0, *)
+struct SettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            SettingsView(viewModel: .init(store: .mock))
+        }
+    }
+}
+#endif
+
+#endif

--- a/Sources/PulseUI/Features/Settings/SettingsView.swift
+++ b/Sources/PulseUI/Features/Settings/SettingsView.swift
@@ -5,15 +5,10 @@
 import SwiftUI
 import Pulse
 
-#if os(iOS) || os(watchOS) || os(tvOS)
-import UniformTypeIdentifiers
+#if os(watchOS) || os(tvOS)
 
 public struct SettingsView: View {
     @ObservedObject var viewModel: SettingsViewModel
-
-#if os(iOS)
-    @State private var isDocumentBrowserPresented = false
-#endif
 
     public init(store: LoggerStore = .shared) {
         // TODO: Fix ownership
@@ -26,7 +21,7 @@ public struct SettingsView: View {
 
     public var body: some View {
         Form {
-            if #available(iOS 14.0, tvOS 14.0, *) {
+            if #available(tvOS 14.0, *) {
                 sectionStoreDetails
             }
 #if os(watchOS)
@@ -37,14 +32,11 @@ public struct SettingsView: View {
                     ButtonRemoveAll(action: viewModel.buttonRemoveAllMessagesTapped)
                 }
             }
-            if #available(iOS 14.0, tvOS 14.0, *), viewModel.isRemoteLoggingAvailable {
+            if #available(tvOS 14.0, *), viewModel.isRemoteLoggingAvailable {
                 Section {
                     RemoteLoggerSettingsView(viewModel: .shared)
                 }
             }
-#if os(iOS)
-            sectionSponsor
-#endif
         }
         .backport.navigationTitle("Settings")
 #if os(tvOS)
@@ -52,7 +44,7 @@ public struct SettingsView: View {
 #endif
     }
 
-    @available(iOS 14.0, tvOS 14.0, *)
+    @available(tvOS 14.0, *)
     private var sectionStoreDetails: some View {
         Section {
             NavigationLink(destination: StoreDetailsView(source: .store(viewModel.store))) {
@@ -61,19 +53,6 @@ public struct SettingsView: View {
                     Text("Store Info")
                 }
             }
-#if os(iOS)
-            if !viewModel.isArchive {
-                Button(action: { isDocumentBrowserPresented = true }) {
-                    HStack {
-                        Image(systemName: "doc")
-                        Text("Browse Stores")
-                    }
-                }
-                .fullScreenCover(isPresented: $isDocumentBrowserPresented) {
-                    DocumentBrowser()
-                }
-            }
-#endif
         }
     }
 
@@ -88,47 +67,12 @@ public struct SettingsView: View {
         }
     }
 #endif
-
-#if os(iOS)
-    private var sectionSponsor: some View {
-        Section(footer: Text("Pulse is funded by the community contributions.")) {
-            Button(action: {
-                if let url = URL(string: "https://github.com/sponsors/kean") {
-                    UIApplication.shared.open(url)
-                }
-            }) {
-                HStack {
-                    Image(systemName: "heart.fill")
-                        .foregroundColor(Color.pink)
-                    Text("Sponsor")
-                        .foregroundColor(Color.primary)
-                    Spacer()
-                    Image(systemName: "link")
-                        .foregroundColor(.secondary)
-                }
-            }
-        }
-    }
-#endif
 }
-
-#if os(iOS)
-@available(iOS 14.0, *)
-private struct DocumentBrowser: UIViewControllerRepresentable {
-    func makeUIViewController(context: Context) -> DocumentBrowserViewController {
-        DocumentBrowserViewController(forOpeningContentTypes: [UTType(filenameExtension: "pulse")].compactMap { $0 })
-    }
-
-    func updateUIViewController(_ uiViewController: DocumentBrowserViewController, context: Context) {
-
-    }
-}
-#endif
 
 // MARK: - Preview
 
 #if DEBUG
-struct ConsoleSettingsView_Previews: PreviewProvider {
+struct SettingsView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
             SettingsView(viewModel: .init(store: .mock))

--- a/Sources/PulseUI/Features/Settings/SettingsView.swift
+++ b/Sources/PulseUI/Features/Settings/SettingsView.swift
@@ -47,9 +47,6 @@ public struct SettingsView: View {
 #endif
         }
         .backport.navigationTitle("Settings")
-#if os(iOS)
-        .navigationBarItems(leading: viewModel.onDismiss.map { Button(action: $0) { Image(systemName: "xmark") } })
-#endif
 #if os(tvOS)
         .frame(maxWidth: 800)
 #endif

--- a/Sources/PulseUI/Features/Settings/SettingsViewModel.swift
+++ b/Sources/PulseUI/Features/Settings/SettingsViewModel.swift
@@ -8,7 +8,6 @@ import Combine
 
 final class SettingsViewModel: ObservableObject {
     let store: LoggerStore
-    var onDismiss: (() -> Void)?
 
     var isArchive: Bool { store.isArchive }
 

--- a/Sources/PulseUI/PulseUI.docc/Documentation.md
+++ b/Sources/PulseUI/PulseUI.docc/Documentation.md
@@ -55,3 +55,7 @@ private let timeFormatter = DateFormatter(format: "HH:mm:ss.SSS")
 ### Other Views
 
 - ``StoreDetailsView``
+
+### Settings
+
+- ``ConsoleSettings``


### PR DESCRIPTION
- Add new context menu to Console and Network screen with many quick actions that were previously hidden in Settings, e.g. "Remove Logs". Settings were removed from the primary tabs `MainView`. With this change, for apps that don't use `MainView` and integrate individual tabs into their own debug menus, integration became significantly eaier because both Console and Network screens are fully self-sufficient.
- Add "Report Issue" button.
- Rework Settings screen on iOS. Add a few new options: `lineLimit` (more options coming in the future PRs)

<img width="648" alt="Screenshot 2022-12-31 at 11 46 11 AM" src="https://user-images.githubusercontent.com/1567433/210150393-18af7693-6759-4de0-9564-e08d106ec400.png">
