### PR TITLE
New mode toggle

### DIFF
--- a/Pulse.xcodeproj/project.pbxproj
+++ b/Pulse.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		0C7A0DFB297C33F300B4B69D /* ConsoleRouterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7A0DFA297C33F300B4B69D /* ConsoleRouterView.swift */; };
 		0C7A0DFD297C382300B4B69D /* ConsoleShareButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7A0DFC297C382300B4B69D /* ConsoleShareButton.swift */; };
 		0C7A0E00297C51CE00B4B69D /* ConsoleListOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7A0DFF297C51CE00B4B69D /* ConsoleListOptions.swift */; };
+		0C7A0E02297CE71400B4B69D /* FormattersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7A0E01297CE71400B4B69D /* FormattersTests.swift */; };
 		0C7A834026D1CA290082634F /* repos.json in Resources */ = {isa = PBXBuildFile; fileRef = 0CFF9BD825D6199A0069DB6A /* repos.json */; };
 		0C9F04F92884F34A0035239F /* Pulse_Demo_macOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C9F04F82884F34A0035239F /* Pulse_Demo_macOSApp.swift */; };
 		0C9F04FD2884F34A0035239F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0C9F04FC2884F34A0035239F /* Assets.xcassets */; };
@@ -545,6 +546,7 @@
 		0C7A0DFA297C33F300B4B69D /* ConsoleRouterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleRouterView.swift; sourceTree = "<group>"; };
 		0C7A0DFC297C382300B4B69D /* ConsoleShareButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleShareButton.swift; sourceTree = "<group>"; };
 		0C7A0DFF297C51CE00B4B69D /* ConsoleListOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleListOptions.swift; sourceTree = "<group>"; };
+		0C7A0E01297CE71400B4B69D /* FormattersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormattersTests.swift; sourceTree = "<group>"; };
 		0C9F04F62884F34A0035239F /* Pulse Demo macOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Pulse Demo macOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		0C9F04F82884F34A0035239F /* Pulse_Demo_macOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pulse_Demo_macOSApp.swift; sourceTree = "<group>"; };
 		0C9F04FC2884F34A0035239F /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -1483,6 +1485,7 @@
 				0CAF1D78297B5FF4002E2722 /* ConsoleSearchServiceTests.swift */,
 				0CAF1D76297B0810002E2722 /* ConsoleSearchSuggestionTests.swift */,
 				0C63A389297A44B300F6A6A5 /* StringSearchOptionsTests.swift */,
+				0C7A0E01297CE71400B4B69D /* FormattersTests.swift */,
 				0CF0D6C9296F18FD00EED9D4 /* MockTests.swift */,
 			);
 			path = PulseUITests;
@@ -2228,6 +2231,7 @@
 			files = (
 				0C63A38A297A44B300F6A6A5 /* StringSearchOptionsTests.swift in Sources */,
 				0CAF1D77297B0810002E2722 /* ConsoleSearchSuggestionTests.swift in Sources */,
+				0C7A0E02297CE71400B4B69D /* FormattersTests.swift in Sources */,
 				0CF0D6CB296F18FD00EED9D4 /* ConsoleViewModelTests.swift in Sources */,
 				0CB63A292975A94D00525165 /* ConsoleSearchTokenTests.swift in Sources */,
 				0CAF1D79297B5FF4002E2722 /* ConsoleSearchServiceTests.swift in Sources */,

--- a/Sources/PulseUI/Features/Console/ConsoleView-ios.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleView-ios.swift
@@ -153,8 +153,13 @@ private struct _ConsoleRegularContentView: View {
 #if DEBUG
 struct ConsoleView_Previews: PreviewProvider {
     static var previews: some View {
-        NavigationView {
-            ConsoleView(viewModel: .init(store: .mock))
+        Group {
+            NavigationView {
+                ConsoleView(viewModel: .init(store: .mock))
+            }.previewDisplayName("Console")
+            NavigationView {
+                ConsoleView.network(store: .mock)
+            }.previewDisplayName("Network")
         }
     }
 }

--- a/Sources/PulseUI/Features/Console/ConsoleView-ios.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleView-ios.swift
@@ -119,9 +119,6 @@ private struct _ConsoleRegularContentView: View {
         } else {
             toolbar
         }
-
-#warning("try pins as an ico ?")
-
         ConsoleListContentView(viewModel: viewModel.list)
         footerView
     }

--- a/Sources/PulseUI/Features/Console/ConsoleView-ios.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleView-ios.swift
@@ -63,6 +63,8 @@ private struct ConsoleListView: View {
         }
         .listStyle(.plain)
 
+#warning("update number of messages")
+
         if #available(iOS 16, *) {
             list
                 .environment(\.defaultMinListRowHeight, 8)
@@ -113,17 +115,56 @@ private struct _ConsoleRegularContentView: View {
     let viewModel: ConsoleViewModel
 
     var body: some View {
-        let toolbar = ConsoleToolbarView(viewModel: viewModel)
-        if #available(iOS 15.0, *) {
-            toolbar.listRowSeparator(.hidden, edges: .top)
-        } else {
-            toolbar
+//        let toolbar = ConsoleToolbarView(viewModel: viewModel)
+//        if #available(iOS 15.0, *) {
+//            toolbar.listRowSeparator(.hidden, edges: .top)
+//        } else {
+//            toolbar
+//        }
+
+#warning("try pins as an ico ?")
+#warning("add swipe actions to change what you see")
+#warning("add underline or something - bold?")
+#warning("can these be a three separate screens?")
+
+//        let picker = Picker("Network", selection: .constant("All")) {
+//        HStack(spacing: 12) {
+////            Text("Scopes").foregroundColor(Color.secondary)
+//            ConsoleFiltersView(isNetworkModeEnabled: true, viewModel: viewModel.searchCriteriaViewModel, router: viewModel.router)
+//            Spacer()
+//            Text("All")
+//            Text("Messages").foregroundColor(Color.secondary)
+//            Text("Network").foregroundColor(Color.secondary)
+//            Text("Pins").foregroundColor(Color.secondary)
+//        }
+//            .font(.subheadline.weight(.medium))
+//            .foregroundColor(Color.blue)
+        let stack = HStack(spacing: 12) {
+            Text("All")
+            Text("Logs").foregroundColor(Color.secondary)
+            + Text(" (4K)").foregroundColor(Color.separator)
+            Text("Tasks").foregroundColor(Color.secondary)
+             + Text(" (12)").foregroundColor(Color.separator)
+//            Text("Pins").foregroundColor(Color.secondary)
+//            + Text("(12)").foregroundColor(Color.separator)
+            Spacer()
+            ConsoleFiltersView(isNetworkModeEnabled: true, viewModel: viewModel.searchCriteriaViewModel, router: viewModel.router)
         }
+            .buttonStyle(.plain)
+            .font(.subheadline.weight(.medium))
+            .foregroundColor(Color.blue)
+
+        if #available(iOS 15.0, *) {
+            stack.listRowSeparator(.hidden, edges: .top)
+        } else {
+            stack
+        }
+
         ConsoleListContentView(viewModel: viewModel.list)
         footerView
     }
 
-    #warning("implement on other platforms and move to the list?")
+#warning("implement on other platforms and move to the list?")
     @ViewBuilder
     private var footerView: some View {
         if #available(iOS 15, *), viewModel.searchCriteriaViewModel.criteria.shared.dates == .session, viewModel.list.options.order == .descending {

--- a/Sources/PulseUI/Features/Console/ConsoleView-ios.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleView-ios.swift
@@ -115,50 +115,17 @@ private struct _ConsoleRegularContentView: View {
     let viewModel: ConsoleViewModel
 
     var body: some View {
-//        let toolbar = ConsoleToolbarView(viewModel: viewModel)
-//        if #available(iOS 15.0, *) {
-//            toolbar.listRowSeparator(.hidden, edges: .top)
-//        } else {
-//            toolbar
-//        }
+        let toolbar = ConsoleToolbarView(viewModel: viewModel)
+        if #available(iOS 15.0, *) {
+            toolbar.listRowSeparator(.hidden, edges: .top)
+        } else {
+            toolbar
+        }
 
 #warning("try pins as an ico ?")
 #warning("add swipe actions to change what you see")
 #warning("add underline or something - bold?")
 #warning("can these be a three separate screens?")
-
-//        let picker = Picker("Network", selection: .constant("All")) {
-//        HStack(spacing: 12) {
-////            Text("Scopes").foregroundColor(Color.secondary)
-//            ConsoleFiltersView(isNetworkModeEnabled: true, viewModel: viewModel.searchCriteriaViewModel, router: viewModel.router)
-//            Spacer()
-//            Text("All")
-//            Text("Messages").foregroundColor(Color.secondary)
-//            Text("Network").foregroundColor(Color.secondary)
-//            Text("Pins").foregroundColor(Color.secondary)
-//        }
-//            .font(.subheadline.weight(.medium))
-//            .foregroundColor(Color.blue)
-        let stack = HStack(spacing: 12) {
-            Text("All")
-            Text("Logs").foregroundColor(Color.secondary)
-            + Text(" (4K)").foregroundColor(Color.separator)
-            Text("Tasks").foregroundColor(Color.secondary)
-             + Text(" (12)").foregroundColor(Color.separator)
-//            Text("Pins").foregroundColor(Color.secondary)
-//            + Text("(12)").foregroundColor(Color.separator)
-            Spacer()
-            ConsoleFiltersView(isNetworkModeEnabled: true, viewModel: viewModel.searchCriteriaViewModel, router: viewModel.router)
-        }
-            .buttonStyle(.plain)
-            .font(.subheadline.weight(.medium))
-            .foregroundColor(Color.blue)
-
-        if #available(iOS 15.0, *) {
-            stack.listRowSeparator(.hidden, edges: .top)
-        } else {
-            stack
-        }
 
         ConsoleListContentView(viewModel: viewModel.list)
         footerView

--- a/Sources/PulseUI/Features/Console/ConsoleView-ios.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleView-ios.swift
@@ -126,6 +126,8 @@ private struct _ConsoleRegularContentView: View {
 #warning("add swipe actions to change what you see")
 #warning("add underline or something - bold?")
 #warning("can these be a three separate screens?")
+#warning("remember persistenly?")
+#warning("reload with animation?")
 
         ConsoleListContentView(viewModel: viewModel.list)
         footerView

--- a/Sources/PulseUI/Features/Console/ConsoleView-ios.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleView-ios.swift
@@ -63,8 +63,6 @@ private struct ConsoleListView: View {
         }
         .listStyle(.plain)
 
-#warning("update number of messages")
-
         if #available(iOS 16, *) {
             list
                 .environment(\.defaultMinListRowHeight, 8)
@@ -123,17 +121,11 @@ private struct _ConsoleRegularContentView: View {
         }
 
 #warning("try pins as an ico ?")
-#warning("add swipe actions to change what you see")
-#warning("add underline or something - bold?")
-#warning("can these be a three separate screens?")
-#warning("remember persistenly?")
-#warning("reload with animation?")
 
         ConsoleListContentView(viewModel: viewModel.list)
         footerView
     }
 
-#warning("implement on other platforms and move to the list?")
     @ViewBuilder
     private var footerView: some View {
         if #available(iOS 15, *), viewModel.searchCriteriaViewModel.criteria.shared.dates == .session, viewModel.list.options.order == .descending {

--- a/Sources/PulseUI/Features/Console/ConsoleView-macos.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleView-macos.swift
@@ -104,7 +104,7 @@ private struct ConsoleToolbarItems: View {
     var body: some View {
         ConsoleSettingsButton(store: viewModel.store)
         Spacer()
-        ConsoleToolbarModePickerButton(viewModel: viewModel.searchCriteriaViewModel)
+        ConsoleToolbarModePickerButton(viewModel: viewModel)
             .keyboardShortcut("n", modifiers: [.command, .shift])
         ConsoleToolbarToggleOnlyErrorsButton(viewModel: viewModel.searchCriteriaViewModel)
             .keyboardShortcut("e", modifiers: [.command, .shift])
@@ -146,13 +146,16 @@ private struct FilterPopoverToolbarButton: View {
 }
 
 private struct ConsoleToolbarModePickerButton: View {
-    @ObservedObject var viewModel: ConsoleSearchCriteriaViewModel
+    let viewModel: ConsoleViewModel
+    @State private var mode: ConsoleMode = .all
 
     var body: some View {
-        Button(action: { viewModel.isOnlyNetwork.toggle() }) {
-            Image(systemName: viewModel.isOnlyNetwork ? "arrow.down.circle.fill" : "arrow.down.circle")
-                .foregroundColor(viewModel.isOnlyNetwork ? Color.accentColor : Color.secondary)
-        }.help("Automatically Scroll to Recent Messages (⇧⌘N)")
+        Button(action: { mode = (mode == .tasks ? .all : .tasks) }) {
+            Image(systemName: mode == .tasks ? "arrow.down.circle.fill" : "arrow.down.circle")
+                .foregroundColor(mode == .tasks ? Color.accentColor : Color.secondary)
+        }
+        .help("Automatically Scroll to Recent Messages (⇧⌘N)")
+        .onChange(of: mode) { viewModel.mode = $0 }
     }
 }
 

--- a/Sources/PulseUI/Features/Console/ConsoleView-tvos.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleView-tvos.swift
@@ -44,10 +44,12 @@ public struct ConsoleView: View {
 
 private struct ConsoleMenuView: View {
     let store: LoggerStore
+    let consoleViewModel: ConsoleViewModel
     @ObservedObject var viewModel: ConsoleSearchCriteriaViewModel
     @ObservedObject var router: ConsoleRouter
 
     init(viewModel: ConsoleViewModel) {
+        self.consoleViewModel = viewModel
         self.store = viewModel.store
         self.viewModel = viewModel.searchCriteriaViewModel
         self.router = viewModel.router
@@ -58,11 +60,11 @@ private struct ConsoleMenuView: View {
             Toggle(isOn: $viewModel.isOnlyErrors) {
                 Label("Errors Only", systemImage: "exclamationmark.octagon")
             }
-            Toggle(isOn: $viewModel.isOnlyNetwork) {
+            Toggle(isOn: consoleViewModel.bindingForNetworkMode) {
                 Label("Network Only", systemImage: "arrow.down.circle")
             }
             NavigationLink(destination: destinationFilters) {
-                Label(viewModel.isOnlyNetwork ? "Network Filters" : "Message Filters", systemImage: "line.3.horizontal.decrease.circle")
+                Label(consoleViewModel.bindingForNetworkMode.wrappedValue ? "Network Filters" : "Message Filters", systemImage: "line.3.horizontal.decrease.circle")
             }
         } header: { Text("Quick Filters") }
         if !store.isArchive {

--- a/Sources/PulseUI/Features/Console/ConsoleView-watchos.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleView-watchos.swift
@@ -38,20 +38,22 @@ public struct ConsoleView: View {
 }
 
 private struct ConsoleToolbarView: View {
+    var consoleViewModel: ConsoleViewModel
     @ObservedObject var viewModel: ConsoleSearchCriteriaViewModel
     @ObservedObject var router: ConsoleRouter
 
     init(viewModel: ConsoleViewModel) {
+        self.consoleViewModel = viewModel
         self.viewModel = viewModel.searchCriteriaViewModel
         self.router = viewModel.router
     }
 
     var body: some View {
         HStack {
-            Button(action: { viewModel.isOnlyNetwork.toggle() } ) {
+            Button(action: { consoleViewModel.bindingForNetworkMode.wrappedValue.toggle() } ) {
                 Image(systemName: "arrow.down.circle")
             }
-            .background(viewModel.isOnlyNetwork ? Rectangle().foregroundColor(.blue).cornerRadius(8) : nil)
+            .background(consoleViewModel.bindingForNetworkMode.wrappedValue ? Rectangle().foregroundColor(.blue).cornerRadius(8) : nil)
 
             Button(action: { viewModel.isOnlyErrors.toggle() }) {
                 Image(systemName: "exclamationmark.octagon")

--- a/Sources/PulseUI/Features/Console/ConsoleViewModel.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleViewModel.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 final class ConsoleViewModel: ObservableObject {
     let title: String
-    let isNetworkModeEnabled: Bool
+    let isNetwork: Bool
     let store: LoggerStore
 
     let list: ConsoleListViewModel
@@ -43,6 +43,14 @@ final class ConsoleViewModel: ObservableObject {
         }
     }
 
+    var bindingForNetworkMode: Binding<Bool> {
+        Binding(get: {
+            self.mode == .tasks
+        }, set: {
+            self.mode = $0 ? .tasks : .all
+        })
+    }
+
     var onDismiss: (() -> Void)?
 
     private var cancellables: [AnyCancellable] = []
@@ -50,7 +58,7 @@ final class ConsoleViewModel: ObservableObject {
     init(store: LoggerStore, isOnlyNetwork: Bool = false) {
         self.title = isOnlyNetwork ? "Network" : "Console"
         self.store = store
-        self.isNetworkModeEnabled = isOnlyNetwork
+        self.isNetwork = isOnlyNetwork
 
         self.searchCriteriaViewModel = ConsoleSearchCriteriaViewModel(store: store)
         self.searchBarViewModel = ConsoleSearchBarViewModel()

--- a/Sources/PulseUI/Features/Console/ConsoleViewModel.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleViewModel.swift
@@ -36,6 +36,13 @@ final class ConsoleViewModel: ObservableObject {
         didSet { refreshListsVisibility() }
     }
 
+    var mode: ConsoleMode = .all {
+        didSet {
+            list.update(mode: mode)
+            searchCriteriaViewModel.mode = mode
+        }
+    }
+
     var onDismiss: (() -> Void)?
 
     private var cancellables: [AnyCancellable] = []

--- a/Sources/PulseUI/Features/Console/List/ConsoleListContentView.swift
+++ b/Sources/PulseUI/Features/Console/List/ConsoleListContentView.swift
@@ -39,7 +39,7 @@ struct ConsoleListContentView: View {
     }
 
     private func makeName(for section: NSFetchedResultsSectionInfo) -> String {
-        if !viewModel.isOnlyNetwork {
+        if viewModel.mode != .tasks  {
             if viewModel.options.messageGroupBy == .level {
                 let rawValue = Int16(Int(section.name) ?? 0)
                 return (LoggerStore.Level(rawValue: rawValue) ?? .debug).name.capitalized

--- a/Sources/PulseUI/Features/Console/List/ConsoleListViewModel.swift
+++ b/Sources/PulseUI/Features/Console/List/ConsoleListViewModel.swift
@@ -8,9 +8,6 @@ import Pulse
 import Combine
 import SwiftUI
 
-#warning("add counters")
-#warning("how to handle groups and sortes for alltab")
-
 final class ConsoleListViewModel: NSObject, NSFetchedResultsControllerDelegate, ObservableObject {
     @Published private(set) var visibleEntities: ArraySlice<NSManagedObject> = []
     @Published private(set) var entities: [NSManagedObject] = []

--- a/Sources/PulseUI/Features/Console/List/ConsoleListViewModel.swift
+++ b/Sources/PulseUI/Features/Console/List/ConsoleListViewModel.swift
@@ -226,7 +226,7 @@ final class ConsoleListViewModel: NSObject, NSFetchedResultsControllerDelegate, 
 
 private let fetchBatchSize = 100
 
-enum ConsoleMode {
+enum ConsoleMode: String {
     case all
     case logs
     case tasks

--- a/Sources/PulseUI/Features/Console/List/ConsoleListViewModel.swift
+++ b/Sources/PulseUI/Features/Console/List/ConsoleListViewModel.swift
@@ -113,7 +113,6 @@ final class ConsoleListViewModel: NSObject, NSFetchedResultsControllerDelegate, 
     }
 
     func refresh() {
-        // Search messages
         guard let controller = controller else {
             return assertionFailure()
         }
@@ -121,7 +120,14 @@ final class ConsoleListViewModel: NSObject, NSFetchedResultsControllerDelegate, 
         if mode == .tasks {
             controller.fetchRequest.predicate = ConsoleSearchCriteria.makeNetworkPredicates(criteria: criteria.criteria, isOnlyErrors: criteria.isOnlyErrors, filterTerm: criteria.filterTerm)
         } else {
-            controller.fetchRequest.predicate = ConsoleSearchCriteria.makeMessagePredicates(criteria: criteria.criteria, isOnlyErrors: criteria.isOnlyErrors, filterTerm: criteria.filterTerm)
+            var predicates: [NSPredicate] = []
+            if mode == .logs {
+                predicates.append(NSPredicate(format: "task == NULL"))
+            }
+            if let predicate = ConsoleSearchCriteria.makeMessagePredicates(criteria: criteria.criteria, isOnlyErrors: criteria.isOnlyErrors, filterTerm: criteria.filterTerm) {
+                predicates.append(predicate)
+            }
+            controller.fetchRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: predicates)
         }
         try? controller.performFetch()
 

--- a/Sources/PulseUI/Features/Console/Views/ConsoleContextMenu-ios.swift
+++ b/Sources/PulseUI/Features/Console/Views/ConsoleContextMenu-ios.swift
@@ -80,7 +80,7 @@ struct ConsoleContextMenu: View {
     @ViewBuilder
     private var sortByMenu: some View {
         Menu(content: {
-            if viewModel.searchCriteriaViewModel.isOnlyNetwork {
+            if viewModel.mode == .tasks {
                 Picker("Sort By", selection: $listViewModel.options.taskSortBy) {
                     ForEach(ConsoleListOptions.TaskSortBy.allCases, id: \.self) {
                         Text($0.rawValue).tag($0)
@@ -105,7 +105,7 @@ struct ConsoleContextMenu: View {
     @ViewBuilder
     private var groupByMenu: some View {
         Menu(content: {
-            if viewModel.searchCriteriaViewModel.isOnlyNetwork {
+            if viewModel.mode == .tasks {
                 Picker("Group By", selection: $listViewModel.options.taskGroupBy) {
                     ForEach(ConsoleListOptions.TaskGroupBy.allCases, id: \.self) {
                         Text($0.rawValue).tag($0)

--- a/Sources/PulseUI/Features/Console/Views/ConsoleEntityCell.swift
+++ b/Sources/PulseUI/Features/Console/Views/ConsoleEntityCell.swift
@@ -30,9 +30,15 @@ private struct _ConsoleMessageCell: View {
     @State private var shareItems: ShareItems?
 
     var body: some View {
+#if os(iOS)
+        let cell = ConsoleMessageCell(viewModel: .init(message: message), isDisclosureNeeded: true)
+            .background(NavigationLink("", destination: LazyConsoleDetailsView(message: message).id(message.objectID)).opacity(0))
+#else
         let cell = NavigationLink(destination: LazyConsoleDetailsView(message: message).id(message.objectID)) {
-            ConsoleMessageCell(viewModel: .init(message: message))
+            ConsoleMessageCell(viewModel: .init(message: message), isDisclosureNeeded: true)
         }
+#endif
+
 #if os(iOS)
         if #available(iOS 15, *) {
             cell.swipeActions(edge: .leading, allowsFullSwipe: true) {
@@ -74,9 +80,15 @@ private struct _ConsoleTaskCell: View {
     @State private var shareItems: ShareItems?
 
     var body: some View {
+#if os(iOS)
+        let cell = ConsoleTaskCell(viewModel: .init(task: task), isDisclosureNeeded: true)
+            .background(NavigationLink("", destination: LazyNetworkInspectorView(task: task).id(task.objectID)).opacity(0))
+#else
         let cell = NavigationLink(destination: LazyNetworkInspectorView(task: task).id(task.objectID)) {
             ConsoleTaskCell(viewModel: .init(task: task))
         }
+#endif
+
 #if os(iOS)
         if #available(iOS 15, *) {
             cell.swipeActions(edge: .leading, allowsFullSwipe: true) {

--- a/Sources/PulseUI/Features/Console/Views/ConsoleMessageCell.swift
+++ b/Sources/PulseUI/Features/Console/Views/ConsoleMessageCell.swift
@@ -9,6 +9,7 @@ import Combine
 
 struct ConsoleMessageCell: View {
     let viewModel: ConsoleMessageCellViewModel
+    var isDisclosureNeeded = false
 
     var body: some View {
         let contents = VStack(alignment: .leading, spacing: 4) {
@@ -22,11 +23,16 @@ struct ConsoleMessageCell: View {
                 PinView(viewModel: viewModel.pinViewModel, font: ConsoleConstants.fontTitle)
                     .frame(width: 4, height: 4) // don't affect layout
 #endif
-                Text(viewModel.time)
-                    .lineLimit(1)
-                    .font(ConsoleConstants.fontTitle)
-                    .foregroundColor(titleColor)
-                    .backport.monospacedDigit()
+                HStack(spacing: 3) {
+                    Text(viewModel.time)
+                        .lineLimit(1)
+                        .font(ConsoleConstants.fontTitle)
+                        .foregroundColor(titleColor)
+                        .backport.monospacedDigit()
+                    if isDisclosureNeeded {
+                        ListDisclosureIndicator()
+                    }
+                }
             }
             Text(viewModel.preprocessedText)
                 .font(ConsoleConstants.fontBody)
@@ -45,6 +51,17 @@ struct ConsoleMessageCell: View {
 
     var titleColor: Color {
         viewModel.message.logLevel >= .warning ? .textColor(for: viewModel.message.logLevel) : .secondary
+    }
+}
+
+struct ListDisclosureIndicator: View {
+    var body: some View {
+        Image(systemName: "chevron.right")
+            .foregroundColor(.separator)
+            .lineLimit(1)
+            .font(ConsoleConstants.fontTitle)
+            .foregroundColor(.secondary)
+            .padding(.trailing, -12)
     }
 }
 

--- a/Sources/PulseUI/Features/Console/Views/ConsoleTaskCell.swift
+++ b/Sources/PulseUI/Features/Console/Views/ConsoleTaskCell.swift
@@ -10,14 +10,16 @@ import CoreData
 struct ConsoleTaskCell: View {
     @ObservedObject var viewModel: ConsoleTaskCellViewModel
     @ObservedObject var progressViewModel: ProgressViewModel
+    let isDisclosureNeeded: Bool
 
-    init(viewModel: ConsoleTaskCellViewModel) {
+    init(viewModel: ConsoleTaskCellViewModel, isDisclosureNeeded: Bool = false) {
         self.viewModel = viewModel
         self.progressViewModel = viewModel.progress
+        self.isDisclosureNeeded = isDisclosureNeeded
     }
 
     var body: some View {
-        let contents = VStack(alignment: .leading, spacing: 5) {
+        let contents = VStack(alignment: .leading, spacing: 6) {
             title
             message
             if viewModel.task.state == .pending {
@@ -53,11 +55,18 @@ struct ConsoleTaskCell: View {
                 .frame(width: 4, height: 4) // don't affect layout
 #endif
 #if !os(watchOS)
-            Text(viewModel.time)
-                .font(ConsoleConstants.fontTitle)
-                .foregroundColor(viewModel.task.state == .failure ? .red : .secondary)
-                .lineLimit(1)
-                .backport.monospacedDigit()
+            HStack(spacing: 3) {
+                Text(viewModel.time)
+                    .font(ConsoleConstants.fontTitle)
+                    .foregroundColor(viewModel.task.state == .failure ? .red : .secondary)
+                    .lineLimit(1)
+                    .backport.monospacedDigit()
+                if isDisclosureNeeded {
+                    if isDisclosureNeeded {
+                        ListDisclosureIndicator()
+                    }
+                }
+            }
 #endif
         }
     }

--- a/Sources/PulseUI/Features/Console/Views/ConsoleToolbarView.swift
+++ b/Sources/PulseUI/Features/Console/Views/ConsoleToolbarView.swift
@@ -14,7 +14,7 @@ struct ConsoleToolbarView: View {
 
     var body: some View {
         HStack(alignment: .bottom, spacing: 0) {
-            ConsoleToolbarTitle(viewModel: viewModel)
+            ConsoleModePicker(viewModel: viewModel)
             Spacer()
             HStack(spacing: 14) {
                 ConsoleFiltersView(
@@ -28,16 +28,25 @@ struct ConsoleToolbarView: View {
     }
 }
 
-private struct ConsoleToolbarTitle: View {
+private struct ConsoleModePicker: View {
     let viewModel: ConsoleViewModel
 
+    @State private var mode: ConsoleMode = .all
     @State private var title: String = ""
 
     var body: some View {
-        Text(title)
-            .foregroundColor(.secondary)
-            .font(.subheadline.weight(.medium))
-            .onReceive(titlePublisher) { title = $0 }
+        HStack(spacing: 12) {
+            ConsoleModeButton(title: "All", isSelected: mode == .all) {
+                viewModel.mode = .all
+            }
+            ConsoleModeButton(title: "Logs", isSelected: mode == .logs) {
+                viewModel.mode = .logs
+            }
+            ConsoleModeButton(title: "Tasks", isSelected: mode == .tasks) {
+                viewModel.mode = .tasks
+            }
+        }
+        .onReceive(viewModel.list.$mode) { mode = $0 }
     }
 
     #warning("remove")
@@ -47,6 +56,24 @@ private struct ConsoleToolbarTitle: View {
                 "\(entities.count) \(viewModel.list.mode == .tasks ? "Requests" : "Messages")"
             }
     }
+}
+
+private struct ConsoleModeButton: View {
+    let title: String
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .foregroundColor(isSelected ? Color.blue : Color.secondary)
+                .font(.subheadline.weight(.medium))
+        }
+        .buttonStyle(.plain)
+    }
+
+#warning("add counters")
+    //  + Text(" (4K)").foregroundColor(Color.separator)
 }
 
 struct ConsoleFiltersView: View {

--- a/Sources/PulseUI/Features/Console/Views/ConsoleToolbarView.swift
+++ b/Sources/PulseUI/Features/Console/Views/ConsoleToolbarView.swift
@@ -30,19 +30,27 @@ struct ConsoleToolbarView: View {
 
 private struct ConsoleModePicker: View {
     let viewModel: ConsoleViewModel
+    @ObservedObject var logsCounter: ManagedObjectsCountObserver
+    @ObservedObject var tasksCounter: ManagedObjectsCountObserver
 
     @State private var mode: ConsoleMode = .all
     @State private var title: String = ""
+
+    init(viewModel: ConsoleViewModel) {
+        self.viewModel = viewModel
+        self.logsCounter = viewModel.list.logCountObserver
+        self.tasksCounter = viewModel.list.taskCountObserver
+    }
 
     var body: some View {
         HStack(spacing: 12) {
             ConsoleModeButton(title: "All", isSelected: mode == .all) {
                 viewModel.mode = .all
             }
-            ConsoleModeButton(title: "Logs", isSelected: mode == .logs) {
+            ConsoleModeButton(title: "Logs", details: "\(logsCounter.count)", isSelected: mode == .logs) {
                 viewModel.mode = .logs
             }
-            ConsoleModeButton(title: "Tasks", isSelected: mode == .tasks) {
+            ConsoleModeButton(title: "Tasks", details: "\(tasksCounter.count)", isSelected: mode == .tasks) {
                 viewModel.mode = .tasks
             }
         }
@@ -60,21 +68,30 @@ private struct ConsoleModePicker: View {
 
 private struct ConsoleModeButton: View {
     let title: String
+    var details: String?
     let isSelected: Bool
     let action: () -> Void
 
     var body: some View {
         Button(action: action) {
-            Text(title)
-                .foregroundColor(isSelected ? Color.blue : Color.secondary)
-                .font(.subheadline.weight(.medium))
+            HStack(spacing: 4) {
+                Text(title)
+                    .foregroundColor(isSelected ? Color.blue : Color.secondary)
+                    .font(.subheadline.weight(.medium))
+                if let details = details {
+                    Text("(\(details))")
+                        .foregroundColor(Color.separator)
+                        .font(.subheadline)
+                }
+            }
         }
         .buttonStyle(.plain)
     }
-
-#warning("add counters")
-    //  + Text(" (4K)").foregroundColor(Color.separator)
 }
+
+#warning("add pin picker?")
+#warning("display pins even from the previous session")
+#warning("remove all pins when pin filter is selected")
 
 struct ConsoleFiltersView: View {
     let isNetworkModeEnabled: Bool
@@ -82,6 +99,11 @@ struct ConsoleFiltersView: View {
     @ObservedObject var router: ConsoleRouter
 
     var body: some View {
+//        Button(action: { viewModel.isOnlyErrors.toggle() }) {
+//            Image(systemName: viewModel.isOnlyErrors ? "pin.square" : "pin.circle")
+//                .font(.system(size: 20))
+//                .foregroundColor(viewModel.isOnlyErrors ? .red : .accentColor)
+//        }
         Button(action: { viewModel.isOnlyErrors.toggle() }) {
             Image(systemName: viewModel.isOnlyErrors ? "exclamationmark.octagon.fill" : "exclamationmark.octagon")
                 .font(.system(size: 20))

--- a/Sources/PulseUI/Features/Console/Views/ConsoleToolbarView.swift
+++ b/Sources/PulseUI/Features/Console/Views/ConsoleToolbarView.swift
@@ -56,14 +56,6 @@ private struct ConsoleModePicker: View {
         }
         .onReceive(viewModel.list.$mode) { mode = $0 }
     }
-
-    #warning("remove")
-    private var titlePublisher: some Publisher<String, Never> {
-        viewModel.list.$entities.combineLatest(viewModel.list.$mode)
-            .map { entities, isOnlyNetwork in
-                "\(entities.count) \(viewModel.list.mode == .tasks ? "Requests" : "Messages")"
-            }
-    }
 }
 
 private struct ConsoleModeButton: View {

--- a/Sources/PulseUI/Features/Console/Views/ConsoleToolbarView.swift
+++ b/Sources/PulseUI/Features/Console/Views/ConsoleToolbarView.swift
@@ -100,20 +100,11 @@ private struct ConsoleModeButton: View {
     }
 }
 
-#warning("add pin picker?")
-#warning("display pins even from the previous session")
-#warning("remove all pins when pin filter is selected")
-
 struct ConsoleFiltersView: View {
     @ObservedObject var viewModel: ConsoleSearchCriteriaViewModel
     @ObservedObject var router: ConsoleRouter
 
     var body: some View {
-//        Button(action: { viewModel.isOnlyErrors.toggle() }) {
-//            Image(systemName: viewModel.isOnlyErrors ? "pin.square" : "pin.circle")
-//                .font(.system(size: 20))
-//                .foregroundColor(viewModel.isOnlyErrors ? .red : .accentColor)
-//        }
         Button(action: { viewModel.isOnlyErrors.toggle() }) {
             Image(systemName: viewModel.isOnlyErrors ? "exclamationmark.octagon.fill" : "exclamationmark.octagon")
                 .font(.system(size: 20))

--- a/Sources/PulseUI/Features/Console/Views/ConsoleToolbarView.swift
+++ b/Sources/PulseUI/Features/Console/Views/ConsoleToolbarView.swift
@@ -14,7 +14,7 @@ struct ConsoleToolbarView: View {
 
     var body: some View {
         HStack(alignment: .bottom, spacing: 0) {
-            if viewModel.isNetworkModeEnabled {
+            if viewModel.isNetwork {
                 ConsoleToolbarTitle(viewModel: viewModel)
             } else {
                 ConsoleModePicker(viewModel: viewModel)

--- a/Sources/PulseUI/Features/Console/Views/ConsoleToolbarView.swift
+++ b/Sources/PulseUI/Features/Console/Views/ConsoleToolbarView.swift
@@ -40,10 +40,11 @@ private struct ConsoleToolbarTitle: View {
             .onReceive(titlePublisher) { title = $0 }
     }
 
+    #warning("remove")
     private var titlePublisher: some Publisher<String, Never> {
-        viewModel.list.$entities.combineLatest(viewModel.searchCriteriaViewModel.$isOnlyNetwork)
+        viewModel.list.$entities.combineLatest(viewModel.list.$mode)
             .map { entities, isOnlyNetwork in
-                "\(entities.count) \(isOnlyNetwork ? "Requests" : "Messages")"
+                "\(entities.count) \(viewModel.list.mode == .tasks ? "Requests" : "Messages")"
             }
     }
 }
@@ -54,13 +55,6 @@ struct ConsoleFiltersView: View {
     @ObservedObject var router: ConsoleRouter
 
     var body: some View {
-        if !isNetworkModeEnabled {
-            Button(action: { viewModel.isOnlyNetwork.toggle() }) {
-                Image(systemName: viewModel.isOnlyNetwork ? "arrow.down.circle.fill" : "arrow.down.circle")
-                    .font(.system(size: 20))
-                    .foregroundColor(.accentColor)
-            }
-        }
         Button(action: { viewModel.isOnlyErrors.toggle() }) {
             Image(systemName: viewModel.isOnlyErrors ? "exclamationmark.octagon.fill" : "exclamationmark.octagon")
                 .font(.system(size: 20))

--- a/Sources/PulseUI/Features/Console/Views/ConsoleToolbarView.swift
+++ b/Sources/PulseUI/Features/Console/Views/ConsoleToolbarView.swift
@@ -14,14 +14,14 @@ struct ConsoleToolbarView: View {
 
     var body: some View {
         HStack(alignment: .bottom, spacing: 0) {
-            ConsoleModePicker(viewModel: viewModel)
+            if viewModel.isNetworkModeEnabled {
+                ConsoleToolbarTitle(viewModel: viewModel)
+            } else {
+                ConsoleModePicker(viewModel: viewModel)
+            }
             Spacer()
             HStack(spacing: 14) {
-                ConsoleFiltersView(
-                    isNetworkModeEnabled: viewModel.isNetworkModeEnabled,
-                    viewModel: viewModel.searchCriteriaViewModel,
-                    router: viewModel.router
-                )
+                ConsoleFiltersView(viewModel: viewModel.searchCriteriaViewModel, router: viewModel.router)
             }
         }
         .buttonStyle(.plain)
@@ -58,6 +58,25 @@ private struct ConsoleModePicker: View {
     }
 }
 
+private struct ConsoleToolbarTitle: View {
+    let viewModel: ConsoleViewModel
+
+    @State private var title: String = ""
+
+    var body: some View {
+        Text(title)
+            .foregroundColor(.secondary)
+            .font(.subheadline.weight(.medium))
+            .onReceive(titlePublisher) { title = $0 }
+    }
+
+    private var titlePublisher: some Publisher<String, Never> {
+        viewModel.list.$entities.map { entities in
+            "\(entities.count) Requests"
+        }
+    }
+}
+
 private struct ConsoleModeButton: View {
     let title: String
     var details: String?
@@ -86,7 +105,6 @@ private struct ConsoleModeButton: View {
 #warning("remove all pins when pin filter is selected")
 
 struct ConsoleFiltersView: View {
-    let isNetworkModeEnabled: Bool
     @ObservedObject var viewModel: ConsoleSearchCriteriaViewModel
     @ObservedObject var router: ConsoleRouter
 

--- a/Sources/PulseUI/Features/Filters/ConsoleSearchCriteriaView.swift
+++ b/Sources/PulseUI/Features/Filters/ConsoleSearchCriteriaView.swift
@@ -47,7 +47,7 @@ struct ConsoleSearchCriteriaView: View {
         timePeriodSection
         generalSection
 
-        if viewModel.isOnlyNetwork {
+        if viewModel.mode == .tasks {
 #if os(iOS) || os(macOS)
             if #available(iOS 15, *) {
                 customNetworkFiltersSection
@@ -224,7 +224,7 @@ private func makePreview(isOnlyNetwork: Bool) -> some View {
     let entities: [NSManagedObject] = try! isOnlyNetwork ? store.allTasks() : store.allMessages()
     let viewModel = ConsoleSearchCriteriaViewModel(store: store)
     viewModel.bind(CurrentValueSubject(entities))
-    viewModel.isOnlyNetwork = isOnlyNetwork
+    viewModel.mode = isOnlyNetwork ? .tasks : .all
     return ConsoleSearchCriteriaView(viewModel: viewModel)
 }
 #endif

--- a/Sources/PulseUI/Features/Filters/ConsoleSearchCriteriaView.swift
+++ b/Sources/PulseUI/Features/Filters/ConsoleSearchCriteriaView.swift
@@ -36,7 +36,7 @@ struct ConsoleSearchCriteriaView: View {
         buttonReset
 #elseif os(macOS)
         HStack {
-            Text(viewModel.isOnlyNetwork ? "Network Filters" : "Message Filters")
+            Text(viewModel.mode == .tasks ? "Network Filters" : "Message Filters")
                 .font(.headline)
             Spacer()
             buttonReset

--- a/Sources/PulseUI/Features/Filters/ConsoleSearchCriteriaViewModel.swift
+++ b/Sources/PulseUI/Features/Filters/ConsoleSearchCriteriaViewModel.swift
@@ -13,6 +13,7 @@ final class ConsoleSearchCriteriaViewModel: ObservableObject {
     @Published var isOnlyErrors = false
     @Published var filterTerm = "" // Legacy, used on non-iOS platforms
     @Published var criteria = ConsoleSearchCriteria()
+    @Published var mode: ConsoleMode = .all
 
     @Published private(set) var labels: [String] = []
     @Published private(set) var domains: [String] = []
@@ -62,10 +63,10 @@ final class ConsoleSearchCriteriaViewModel: ObservableObject {
 
     var isCriteriaDefault: Bool {
         guard criteria.shared == defaultCriteria.shared else { return false }
-        if isOnlyNetwork {
-            return criteria.messages == defaultCriteria.messages
-        } else {
+        if mode == .tasks {
             return criteria.network == defaultCriteria.network
+        } else {
+            return criteria.messages == defaultCriteria.messages
         }
     }
 
@@ -88,7 +89,7 @@ final class ConsoleSearchCriteriaViewModel: ObservableObject {
     }
 
     private func reloadCounters() {
-        if isOnlyNetwork {
+        if mode == .tasks {
             guard let tasks = entities as? [NetworkTaskEntity] else {
                 return assertionFailure()
             }

--- a/Sources/PulseUI/Features/Filters/ConsoleSearchCriteriaViewModel.swift
+++ b/Sources/PulseUI/Features/Filters/ConsoleSearchCriteriaViewModel.swift
@@ -11,7 +11,6 @@ final class ConsoleSearchCriteriaViewModel: ObservableObject {
     var isButtonResetEnabled: Bool { !isCriteriaDefault }
 
     @Published var isOnlyErrors = false
-    @Published var isOnlyNetwork = false
     @Published var filterTerm = "" // Legacy, used on non-iOS platforms
     @Published var criteria = ConsoleSearchCriteria()
 

--- a/Sources/PulseUI/Features/Search/Views/ConsoleSearchSuggestionView.swift
+++ b/Sources/PulseUI/Features/Search/Views/ConsoleSearchSuggestionView.swift
@@ -36,10 +36,20 @@ struct ConsoleSearchSuggestionView: View {
                     .lineLimit(1)
                 Spacer()
                 if isActionable {
-                    Text("\\t")
-                        .foregroundColor(.separator)
+                    ShortcutTooltip(title: "Tab")
                 }
             }
         }
+    }
+}
+
+struct ShortcutTooltip: View {
+    let title: String
+
+    var body: some View {
+        Text(title)
+            .font(.caption)
+            .foregroundColor(.separator)
+            .background(Rectangle().frame(width: 34, height: 28).foregroundColor(Color.separator.opacity(0.2)).cornerRadius(8))
     }
 }

--- a/Sources/PulseUI/Features/Search/Views/ConsoleSearchToolbar.swift
+++ b/Sources/PulseUI/Features/Search/Views/ConsoleSearchToolbar.swift
@@ -27,7 +27,7 @@ struct ConsoleSearchToolbar: View {
             Spacer()
             HStack(spacing: 14) {
                 ConsoleSearchContextMenu(viewModel: viewModel.searchViewModel)
-                ConsoleFiltersView(isNetworkModeEnabled: viewModel.isNetworkModeEnabled, viewModel: viewModel.searchCriteriaViewModel, router: viewModel.router)
+                ConsoleFiltersView(viewModel: viewModel.searchCriteriaViewModel, router: viewModel.router)
             }
         }
         .buttonStyle(.plain)

--- a/Sources/PulseUI/Features/Settings/ConsoleSettings.swift
+++ b/Sources/PulseUI/Features/Settings/ConsoleSettings.swift
@@ -31,9 +31,6 @@ final class ConsoleSettings: PersistentSettings {
 
     @UserDefault("recent-filters")
     var recentFilters: String = "[]"
-
-    @UserDefault("selected-console-mode")
-    var selectedConsoleMode: String = ConsoleMode.all.rawValue
 }
 
 final class ConsoleTextViewSettings: PersistentSettings {

--- a/Sources/PulseUI/Features/Settings/ConsoleSettings.swift
+++ b/Sources/PulseUI/Features/Settings/ConsoleSettings.swift
@@ -31,6 +31,9 @@ final class ConsoleSettings: PersistentSettings {
 
     @UserDefault("recent-filters")
     var recentFilters: String = "[]"
+
+    @UserDefault("selected-console-mode")
+    var selectedConsoleMode: String = ConsoleMode.all.rawValue
 }
 
 final class ConsoleTextViewSettings: PersistentSettings {

--- a/Sources/PulseUI/Helpers/Formatters.swift
+++ b/Sources/PulseUI/Helpers/Formatters.swift
@@ -168,3 +168,18 @@ extension ByteCountFormatter {
         ByteCountFormatter.string(fromByteCount: count, countStyle: .file)
     }
 }
+
+enum CountFormatter {
+    private static let numberFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 1
+        return formatter
+    }()
+
+    static func string(from count: Int) -> String {
+        if count < 1000 { return "\(count)" }
+        let number = NSNumber(floatLiteral: Double(count) / 1000.0)
+        return (numberFormatter.string(from: number) ?? "–") + "k"
+    }
+}

--- a/Sources/PulseUI/Helpers/ManagedObjectsObserver.swift
+++ b/Sources/PulseUI/Helpers/ManagedObjectsObserver.swift
@@ -30,3 +30,37 @@ final class ManagedObjectsObserver<T: NSManagedObject>: NSObject, ObservableObje
         self.objects = self.controller.fetchedObjects ?? []
     }
 }
+
+final class ManagedObjectsCountObserver: NSObject, ObservableObject, NSFetchedResultsControllerDelegate {
+    let controller: NSFetchedResultsController<NSManagedObject>
+
+    @Published private(set) var count = 0
+
+    init<T: NSManagedObject>(entity: T.Type, context: NSManagedObjectContext, sortDescriptior: NSSortDescriptor) {
+        let request = NSFetchRequest<NSManagedObject>(entityName: "\(T.self)")
+        request.fetchBatchSize = 1
+        request.sortDescriptors = [sortDescriptior]
+
+        self.controller = NSFetchedResultsController<NSManagedObject>(fetchRequest: request, managedObjectContext: context, sectionNameKeyPath: nil, cacheName: nil)
+
+        super.init()
+
+        self.controller.delegate = self
+        self.refresh()
+    }
+
+    func setPredicate(_ predicate: NSPredicate?) {
+        controller.fetchRequest.predicate = predicate
+        refresh()
+    }
+
+    func refresh() {
+        try? controller.performFetch()
+        self.count = controller.fetchedObjects?.count ?? 0
+    }
+
+    func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
+        self.count = controller.fetchedObjects?.count ?? 0
+    }
+}
+

--- a/Sources/PulseUI/PulseUI.docc/Documentation.md
+++ b/Sources/PulseUI/PulseUI.docc/Documentation.md
@@ -20,6 +20,8 @@ The easiest way to integrate PulseUI is by using ``ConsoleView``.
 
 Alternatively, you can use native `UIHostingController` to present it in any `UIKit` context.
 
+> tip: If you use Pulse to log only nework requests, and not text messages, use `ConsoleView.network()` to show a view specialized to only display network requests. 
+
 ## Custom Views
 
 PulseUI gives you complete access to the underlying data and its model. You can easily create custom views into your log data by using affordances provided by SwiftUI:

--- a/Sources/PulseUI/PulseUI.docc/Documentation.md
+++ b/Sources/PulseUI/PulseUI.docc/Documentation.md
@@ -20,7 +20,7 @@ The easiest way to integrate PulseUI is by using ``ConsoleView``.
 
 Alternatively, you can use native `UIHostingController` to present it in any `UIKit` context.
 
-> tip: If you use Pulse to log only nework requests, and not text messages, use `ConsoleView.network()` to show a view specialized to only display network requests. 
+> tip: If you use Pulse to log only network requests, and not text messages, use `ConsoleView.network()` to show a view specialized to only display network requests. 
 
 ## Custom Views
 

--- a/Tests/PulseUITests/FormattersTests.swift
+++ b/Tests/PulseUITests/FormattersTests.swift
@@ -1,0 +1,18 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
+
+import XCTest
+@testable import Pulse
+@testable import PulseUI
+
+final class FormattersTests: XCTestCase {
+    func testCountFormatter() throws {
+        XCTAssertEqual(CountFormatter.string(from: 10), "10")
+        XCTAssertEqual(CountFormatter.string(from: 999), "999")
+        XCTAssertEqual(CountFormatter.string(from: 1000), "1k")
+        XCTAssertEqual(CountFormatter.string(from: 1049), "1k")
+        XCTAssertEqual(CountFormatter.string(from: 1099), "1.1k")
+        XCTAssertEqual(CountFormatter.string(from: 1100), "1.1k")
+    }
+}


### PR DESCRIPTION
Add a new mode picker: "All", "Logs", "Tasks". Pulse 2.x had two separate tabs (TabView): one for all messages and one for network requests. In v3.0 they were "demoted" to a single selectable button in the Console's toolbar that wasn't easily discoverable. The new dedicated mode picker in v3.2 has a number of advantages: easily discoverable, shows individual counters for logs and tasks, and also enables new "Logs" mode where only regular logs are displayed.

<img width="664" alt="Screenshot 2023-01-21 at 11 49 00 PM" src="https://user-images.githubusercontent.com/1567433/213901157-64973247-a721-4b9d-9e0c-76bfc6bd087f.png">
