### PR TITLE
Fix `ProgressViewModel` retain cycle

### DIFF
--- a/Sources/PulseUI/Views/SpinnerView.swift
+++ b/Sources/PulseUI/Views/SpinnerView.swift
@@ -83,8 +83,8 @@ final class ProgressViewModel: ObservableObject {
 
     private func register(for progress: NetworkTaskProgressEntity) {
         self.refresh(with: progress)
-        observer2 = progress.objectWillChange.sink { [self] in
-            self.refresh(with: progress)
+        observer2 = progress.objectWillChange.sink { [weak self] in
+            self?.refresh(with: progress)
         }
     }
 


### PR DESCRIPTION
This PR removes a retain cycle in `ProgressViewModel`’s progress observation.