### PR TITLE
Fix Labels and Hosts filter selections.

### DIFF
--- a/Sources/PulseUI/Features/Console/ConsoleView-tvos.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleView-tvos.swift
@@ -72,7 +72,11 @@ private struct ConsoleMenuView: View {
                 NavigationLink(destination: destinationStoreDetails) {
                     Label("Store Info", systemImage: "info.circle")
                 }
-                Button.destructive(action: store.removeAll) {
+                Button.destructive {
+                    viewModel.accumulatedLabels = []
+                    viewModel.accumulatedHosts = []
+                    store.removeAll()
+                } label: {
                     Label("Remove Logs", systemImage: "trash")
                 }
             } header: { Text("Store") }

--- a/Sources/PulseUI/Features/Console/ConsoleViewModel.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleViewModel.swift
@@ -80,6 +80,8 @@ final class ConsoleViewModel: ObservableObject {
 
         prepare(for: mode)
         searchCriteriaViewModel.bind(list.$entities)
+        searchCriteriaViewModel.bind(accumulatedLabels: list.$accumulatedLabels)
+        searchCriteriaViewModel.bind(accumulatedHosts: list.$accumulatedHosts)
     }
 
     private func prepare(for mode: ConsoleMode) {

--- a/Sources/PulseUI/Features/Console/List/ConsoleListViewModel.swift
+++ b/Sources/PulseUI/Features/Console/List/ConsoleListViewModel.swift
@@ -13,6 +13,8 @@ final class ConsoleListViewModel: NSObject, NSFetchedResultsControllerDelegate, 
     @Published private(set) var pins: [NSManagedObject] = []
     @Published private(set) var entities: [NSManagedObject] = []
     @Published private(set) var sections: [NSFetchedResultsSectionInfo]?
+    @Published private(set) var accumulatedLabels: Set<String> = []
+    @Published private(set) var accumulatedHosts: Set<String> = []
     @Published var options = ConsoleListOptions()
 
     let entitiesSubject = CurrentValueSubject<[NSManagedObject], Never>([])
@@ -251,6 +253,12 @@ final class ConsoleListViewModel: NSObject, NSFetchedResultsControllerDelegate, 
     }
 
     private func reloadMessages(isMandatory: Bool = true) {
+        if let entities = entities as? [LoggerMessageEntity] {
+            accumulatedLabels = accumulatedLabels.union(Set(entities.map(\.label)))
+        }
+        if let entities = entities as? [NetworkTaskEntity] {
+            accumulatedHosts = accumulatedHosts.union(Set(entities.compactMap(\.host)))
+        }
         entities = controller?.fetchedObjects ?? []
         sections = controller?.sectionNameKeyPath == nil ?  nil : controller?.sections
         if isMandatory || scrollPosition == .nearTop {

--- a/Sources/PulseUI/Features/Console/Views/ConsoleContextMenu-ios.swift
+++ b/Sources/PulseUI/Features/Console/Views/ConsoleContextMenu-ios.swift
@@ -72,7 +72,10 @@ struct ConsoleContextMenu: View {
 
     private func buttonRemoveAllTapped() {
         viewModel.store.removeAll()
-
+        
+        viewModel.searchCriteriaViewModel.accumulatedLabels = []
+        viewModel.searchCriteriaViewModel.accumulatedHosts = []
+        
         runHapticFeedback(.success)
         ToastView {
             HStack {

--- a/Sources/PulseUI/Features/Filters/ConsoleSearchCriteriaView.swift
+++ b/Sources/PulseUI/Features/Filters/ConsoleSearchCriteriaView.swift
@@ -112,7 +112,7 @@ extension ConsoleSearchCriteriaView {
         }, content: {
             ConsoleSearchListSelectionView(
                 title: "Labels",
-                items: viewModel.labels,
+                items: Array(viewModel.accumulatedLabels),
                 selection: $viewModel.selectedLabels,
                 description: { $0 },
                 label: {


### PR DESCRIPTION
Accumulated labels and hosts store all the hosts and labels of the liftime of the logger. This is used for filteriing logs where the labels and hosts are filtered out and removed from the lists in the filter views.