### PR TITLE
tvOS not logging on real device

### DIFF
--- a/Sources/Pulse/Helpers/Extensions.swift
+++ b/Sources/Pulse/Helpers/Extensions.swift
@@ -34,7 +34,13 @@ extension URL {
     }
 
     static var logs: URL {
-        var url = Files.urls(for: .libraryDirectory, in: .userDomainMask).first?
+        var searchPath = FileManager.SearchPathDirectory.documentDirectory
+        
+        #if os(tvOS)
+        searchPath = .cachesDirectory
+        #endif
+        
+        var url = Files.urls(for: searchPath, in: .userDomainMask).first?
             .appending(directory: "Logs")
             .appending(directory: "com.github.kean.logger")  ?? URL(fileURLWithPath: "/dev/null")
         if !Files.createDirectoryIfNeeded(at: url) {

--- a/Sources/Pulse/LoggerStore/LoggerStore.swift
+++ b/Sources/Pulse/LoggerStore/LoggerStore.swift
@@ -70,11 +70,14 @@ public final class LoggerStore: @unchecked Sendable {
 
     private static func makeDefault() -> LoggerStore {
         let storeURL = URL.logs.appending(directory: "current.pulse")
-        guard let store = try? LoggerStore(storeURL: storeURL, options: [.create, .sweep]) else {
-            return LoggerStore(inMemoryStore: storeURL) // Right side should never happen
+        if let store = try? LoggerStore(storeURL: storeURL, options: [.create, .sweep]) {
+            register(store: store)
+            return store
+        } else {
+            let memoryStore = LoggerStore(inMemoryStore: storeURL) // Right side should never happen
+            register(store: memoryStore)
+            return memoryStore
         }
-        register(store: store)
-        return store
     }
 
     // MARK: Initialization


### PR DESCRIPTION
The fallback was never being registered. Once registered it seems to be configured and allow the user to enable remote logging etc. There may be assumptions elsewhere as the logs still don’t seem to persist. This likely requires more investigation.

Use the caches directory for appleTV hardware as this is the only available directory on tvOS. It is more temporary, and often is cleared on backgrounding, but at least it’s available.