### PR TITLE
Add TaskMessageBuilder to change what is shown in the list

### DIFF
--- a/Pulse.xcodeproj/project.pbxproj
+++ b/Pulse.xcodeproj/project.pbxproj
@@ -289,6 +289,7 @@
 		0CF5E60629981A94009FF7AE /* ShareStoreViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF5E60529981A94009FF7AE /* ShareStoreViewModelTests.swift */; };
 		0CF5E60929981ADF009FF7AE /* ShareStoreViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF5E60729981ADC009FF7AE /* ShareStoreViewModel.swift */; };
 		0CFBC5AF2991DCD30038E547 /* ThickDivider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFBC5AE2991DCD30038E547 /* ThickDivider.swift */; };
+		C8B525DA29BE3929008CA993 /* TaskMessageBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8B525D929BE3929008CA993 /* TaskMessageBuilder.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -776,6 +777,7 @@
 		0CFF9BD825D6199A0069DB6A /* repos.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = repos.json; sourceTree = "<group>"; };
 		49E82A8526D107A00070244F /* AlamofireIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlamofireIntegration.swift; sourceTree = "<group>"; };
 		49E82A8826D1083D0070244F /* MoyaIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoyaIntegration.swift; sourceTree = "<group>"; };
+		C8B525D929BE3929008CA993 /* TaskMessageBuilder.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskMessageBuilder.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1503,6 +1505,7 @@
 				0CF0D5FB296F189600EED9D4 /* ConsoleView-watchos.swift */,
 				0CF0D60A296F189600EED9D4 /* ConsoleViewModel.swift */,
 				0CECF63C2996BE12000F9CCD /* ConsoleDataSource.swift */,
+				C8B525D929BE3929008CA993 /* TaskMessageBuilder.swift */,
 			);
 			path = Console;
 			sourceTree = "<group>";
@@ -2190,6 +2193,7 @@
 				0C4BF92D298817EC0086A6A7 /* IntlineTabBar.swift in Sources */,
 				0C40C0A2296F81B0009ECF16 /* ConsoleCustomFilterView.swift in Sources */,
 				0CF0D682296F189600EED9D4 /* ConsoleTextView.swift in Sources */,
+				C8B525DA29BE3929008CA993 /* TaskMessageBuilder.swift in Sources */,
 				0CF0D645296F189600EED9D4 /* ConsoleSearchSectionHeader.swift in Sources */,
 				0CF0D62A296F189600EED9D4 /* KeyValueSectionViewModel.swift in Sources */,
 				0CF0D638296F189600EED9D4 /* ImageViewer.swift in Sources */,

--- a/Sources/PulseUI/Features/Console/TaskMessageBuilder.swift
+++ b/Sources/PulseUI/Features/Console/TaskMessageBuilder.swift
@@ -1,0 +1,35 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
+
+import Foundation
+import Pulse
+import SwiftUI
+
+/// A global set of configuration for the console.
+/// These values can be changed to customize default behavior.
+public enum ConsoleConfiguration {
+    /// Global message builder for rows
+    public static var messageBuilder: TaskMessageBuilder = URLTaskMessageBuilder()
+}
+
+/// A message builder is used to build information about the task to be displayed in
+/// the console list
+public protocol TaskMessageBuilder {
+    /// Build the view to be displayed in the console list
+    func buildView(task: NetworkTaskEntity) -> AnyView
+}
+
+/// A simple task message builder that displays the URL only
+public struct URLTaskMessageBuilder: TaskMessageBuilder {
+    public init() {}
+
+    public func buildView(task: NetworkTaskEntity) -> AnyView {
+        AnyView(
+            Text(task.url ?? "–")
+                .font(ConsoleConstants.fontBody)
+                .foregroundColor(.primary)
+                .lineLimit(ConsoleSettings.shared.lineLimit)
+        )
+    }
+}

--- a/Sources/PulseUI/Features/Console/Views/ConsoleTaskCell.swift
+++ b/Sources/PulseUI/Features/Console/Views/ConsoleTaskCell.swift
@@ -87,10 +87,7 @@ struct ConsoleTaskCell: View {
     }
 
     private var message: some View {
-        Text(task.url ?? "–")
-            .font(ConsoleConstants.fontBody)
-            .foregroundColor(.primary)
-            .lineLimit(ConsoleSettings.shared.lineLimit)
+        ConsoleConfiguration.messageBuilder.buildView(task: task)
     }
 
     private var details: some View {


### PR DESCRIPTION
* Introduce a way to customize the look of the list.
* `TaskMessageBuilder` is a protocol that takes a `NetworkTaskEntity` and returns a view.
* The default implementation is unchanged where it displays a `Text` with the url only
* This can be used to customize what else gets displayed since the entire task is available. 
