### PR TITLE
Add option to display custom headers in the list view

### DIFF
--- a/Sources/PulseUI/Features/Console/ConsoleDataSource.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleDataSource.swift
@@ -18,9 +18,6 @@ protocol ConsoleDataSourceDelegate: AnyObject {
 }
 
 final class ConsoleDataSource: NSObject, NSFetchedResultsControllerDelegate {
-    private(set) var entities: [NSManagedObject] = []
-    private(set) var sections: [NSFetchedResultsSectionInfo]?
-
     weak var delegate: ConsoleDataSourceDelegate?
 
     /// - warning: Incompatible with the "group by" option.
@@ -81,6 +78,7 @@ final class ConsoleDataSource: NSObject, NSFetchedResultsControllerDelegate {
             NSSortDescriptor(key: sortKey, ascending: options.order == .ascending)
         ].compactMap { $0 }
         request.fetchBatchSize = ConsoleDataSource.fetchBatchSize
+        request.relationshipKeyPathsForPrefetching = ["request"]
         controller = NSFetchedResultsController(
             fetchRequest: request,
             managedObjectContext: store.viewContext,
@@ -113,25 +111,35 @@ final class ConsoleDataSource: NSObject, NSFetchedResultsControllerDelegate {
 
     func refresh() {
         try? controller.performFetch()
-        refreshEntities()
         delegate?.dataSourceDidRefresh(self)
     }
-
+    
+    // MARK: Accessing Entities
+    
+    var numberOfObjects: Int {
+        controller.fetchedObjects?.count ?? 0
+    }
+    
+    func object(at indexPath: IndexPath) -> NSManagedObject {
+        controller.object(at: indexPath)
+    }
+    
+    var entities: [NSManagedObject] {
+        controller.fetchedObjects ?? []
+    }
+    
+    var sections: [NSFetchedResultsSectionInfo]? {
+        controller.sectionNameKeyPath == nil ? nil : controller.sections
+    }
+    
     // MARK: NSFetchedResultsControllerDelegate
 
     func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
-        refreshEntities()
         delegate?.dataSource(self, didUpdateWith: nil)
     }
 
     func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChangeContentWith diff: CollectionDifference<NSManagedObjectID>) {
-        refreshEntities()
         delegate?.dataSource(self, didUpdateWith: diff)
-    }
-
-    private func refreshEntities() {
-        entities = controller.fetchedObjects ?? []
-        sections = controller.sectionNameKeyPath == nil ?  nil : controller.sections
     }
 
     // MARK: Predicate

--- a/Sources/PulseUI/Features/Console/Views/ConsoleEntityDetailsView.swift
+++ b/Sources/PulseUI/Features/Console/Views/ConsoleEntityDetailsView.swift
@@ -46,7 +46,7 @@ struct ConsoleEntityDetailsRouterView: View {
 }
 
 struct ButtonChangeContentModeLayout: View {
-    @SceneStorage("is-details-vertical") private var isVertical = false
+    @SceneStorage("scene-is-details-vertical") private var isVertical = AppSettings.shared.isVertical
 
     var body: some View {
         Button(action: { isVertical.toggle() }, label: {
@@ -55,6 +55,9 @@ struct ButtonChangeContentModeLayout: View {
         })
         .help(isVertical ? "Switch to Horizontal Layout" : "Switch to Vertical Layout")
         .buttonStyle(.plain)
+        .onChange(of: isVertical) {
+            AppSettings.shared.isVertical = $0
+        }
     }
 }
 

--- a/Sources/PulseUI/Features/Console/Views/ConsoleTaskCell.swift
+++ b/Sources/PulseUI/Features/Console/Views/ConsoleTaskCell.swift
@@ -90,7 +90,7 @@ struct ConsoleTaskCell: View {
 
             ForEach(headerValueMap.keys.sorted(), id: \.self) { key in
                 HStack {
-                    Text(key.uppercased())
+                    Text(key)
                         .font(.caption)
                         .foregroundColor(.secondary)
 

--- a/Sources/PulseUI/Features/Console/Views/ConsoleTaskCell.swift
+++ b/Sources/PulseUI/Features/Console/Views/ConsoleTaskCell.swift
@@ -74,10 +74,33 @@ struct ConsoleTaskCell: View {
     }
 
     private var message: some View {
-        Text(task.url ?? "–")
-            .font(ConsoleConstants.fontBody)
-            .foregroundColor(.primary)
-            .lineLimit(settings.lineLimit)
+        VStack(spacing: 3) {
+            HStack {
+                Text(task.url ?? "–")
+                    .font(ConsoleConstants.fontBody)
+                    .foregroundColor(.primary)
+                    .lineLimit(settings.lineLimit)
+
+                Spacer()
+            }
+
+            let headerValueMap = settings.displayHeaders.reduce(into: [String: String]()) { partialResult, header in
+                partialResult[header] = task.originalRequest?.headers[header]
+            }
+
+            ForEach(headerValueMap.keys.sorted(), id: \.self) { key in
+                HStack {
+                    Text(key.uppercased())
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+
+                    Text(headerValueMap[key] ?? "-")
+                        .font(.callout)
+                        .bold()
+                    Spacer()
+                }
+            }
+        }
     }
 
     private var details: some View {

--- a/Sources/PulseUI/Features/Settings/SettingsView-ios.swift
+++ b/Sources/PulseUI/Features/Settings/SettingsView-ios.swift
@@ -10,7 +10,7 @@ import UniformTypeIdentifiers
 
 public struct SettingsView: View {
     @ObservedObject var viewModel: SettingsViewModel
-
+    @State private var newHeaderName = ""
     @EnvironmentObject private var settings: UserSettings
 
     public init(store: LoggerStore = .shared) {
@@ -33,6 +33,28 @@ public struct SettingsView: View {
             if viewModel.isRemoteLoggingAvailable {
                 Section {
                     RemoteLoggerSettingsView(viewModel: .shared)
+                }
+            }
+
+            Section(header: Text("List headers"), footer: Text("These headers will be included in the list view")) {
+                ForEach(settings.displayHeaders, id: \.self) {
+                    Text($0)
+                }
+                .onDelete { indices in
+                    settings.displayHeaders.remove(atOffsets: indices)
+                }
+                HStack {
+                    TextField("New Header", text: $newHeaderName)
+                    Button(action: {
+                        withAnimation {
+                            settings.displayHeaders.append(newHeaderName)
+                            newHeaderName = ""
+                        }
+                    }) {
+                        Image(systemName: "plus.circle.fill")
+                            .accessibilityLabel("Add header")
+                    }
+                    .disabled(newHeaderName.isEmpty)
                 }
             }
         }

--- a/Sources/PulseUI/Features/Settings/UserSettings.swift
+++ b/Sources/PulseUI/Features/Settings/UserSettings.swift
@@ -17,4 +17,29 @@ final class UserSettings: ObservableObject {
 
     @AppStorage("sharing-output")
     var sharingOutput: ShareStoreOutput = .store
+
+    @AppStorage("display-headers")
+    var displayHeaders: [String] = []
+}
+
+// MARK: - Array + RawREpresentable
+
+extension Array: RawRepresentable where Element: Codable {
+    public init?(rawValue: String) {
+        guard let data = rawValue.data(using: .utf8),
+              let result = try? JSONDecoder().decode([Element].self, from: data)
+        else {
+            return nil
+        }
+        self = result
+    }
+
+    public var rawValue: String {
+        guard let data = try? JSONEncoder().encode(self),
+              let result = String(data: data, encoding: .utf8)
+        else {
+            return "[]"
+        }
+        return result
+    }
 }

--- a/Sources/PulseUI/Views/ContextMenus.swift
+++ b/Sources/PulseUI/Views/ContextMenus.swift
@@ -80,9 +80,6 @@ enum ContextMenu {
 //                    NetworkTaskFilterMenu(task: task)
 //                }
 //            }
-#if PULSE_STANDALONE_APP
-            StandaloneNetworkTaskContextMenu(task: task)
-#endif
             if let message = task.message {
                 Section {
                     PinButton(viewModel: .init(message))


### PR DESCRIPTION
Adding an option to customize the list on iOS to be able to show any header value through the Settings page.

* The headers that should be displayed in the list can be added easily from the Settings page
* Can delete any watched header key by swiping

This is a replacement of #174 

Screenshots
---

List view

![Simulator Screenshot - iPhone 14 Pro - 2023-06-04 at 13 41 12](https://github.com/kean/Pulse/assets/12048108/0441e121-d9b2-49b3-938b-150d88e5a2c5)

Settings

![Simulator Screenshot - iPhone 14 Pro - 2023-06-04 at 13 41 44](https://github.com/kean/Pulse/assets/12048108/c90664c9-3e56-4cd3-b02c-3d0862091d3a)
![Simulator Screenshot - iPhone 14 Pro - 2023-06-04 at 13 41 53](https://github.com/kean/Pulse/assets/12048108/70567e5a-189c-44ac-8eaa-e4fcbc1cfcd4)
