### PR TITLE
Add createdAt parameter to Logger.storeMessage

### DIFF
--- a/Sources/Pulse/LoggerStore/LoggerStore.swift
+++ b/Sources/Pulse/LoggerStore/LoggerStore.swift
@@ -276,9 +276,9 @@ public final class LoggerStore: @unchecked Sendable, Identifiable {
 
 extension LoggerStore {
     /// Stores the given message.
-    public func storeMessage(label: String, level: Level, message: String, metadata: [String: MetadataValue]? = nil, file: String = #file, function: String = #function, line: UInt = #line) {
+    public func storeMessage(createdAt: Date? = nil, label: String, level: Level, message: String, metadata: [String: MetadataValue]? = nil, file: String = #file, function: String = #function, line: UInt = #line) {
         handle(.messageStored(.init(
-            createdAt: configuration.makeCurrentDate(),
+            createdAt: createdAt ?? configuration.makeCurrentDate(),
             label: label,
             level: level,
             message: message,


### PR DESCRIPTION
This enables writing log messages from external sources into the `LoggerStore` 