### PR TITLE
fix: Searching removes the backgroundColor of DecodingError highlighted text. 🎨

### DIFF
--- a/Sources/PulseUI/Views/RichTextView/RichTextViewModel.swift
+++ b/Sources/PulseUI/Views/RichTextView/RichTextViewModel.swift
@@ -42,6 +42,7 @@ final class RichTextViewModel: ObservableObject {
     struct SearchMatch {
         let range: NSRange
         let originalForegroundColor: UXColor
+        let originalBackgroundColor: UXColor?
     }
 
     convenience init(string: NSAttributedString = NSAttributedString()) {
@@ -148,7 +149,9 @@ final class RichTextViewModel: ObservableObject {
                 textStorage.attributes(at: $0.location, effectiveRange: nil)[.isTechnical] == nil
             }.map {
                 let color = textStorage.attribute(.foregroundColor, at: $0.location, effectiveRange: nil) as? UXColor
-                return SearchMatch(range: $0, originalForegroundColor: color ?? .label)
+                let backgroundColor = textStorage.attribute(.backgroundColor, at: $0.location, effectiveRange: nil) as? UXColor
+
+                return SearchMatch(range: $0, originalForegroundColor: color ?? .label, originalBackgroundColor: backgroundColor)
             }
 
             for match in matches {
@@ -225,6 +228,9 @@ final class RichTextViewModel: ObservableObject {
 #else
             textStorage.addAttribute(.foregroundColor, value: match.originalForegroundColor, range: range)
             textStorage.removeAttribute(.backgroundColor, range: range)
+            if let backgroundColor = match.originalBackgroundColor {
+                textStorage.addAttribute(.backgroundColor, value: backgroundColor, range: range)
+            }
 #endif
         }
     }


### PR DESCRIPTION
### Description.
I've fixed the issue that is raised with this number #208.
I've added a new property to hold the original background color as an optional property, and optionally bind it when clearing the search match to return back to its initial state. 

### gif example

![Simulator Screen Recording - iPhone SE (3rd generation) - 2023-08-07 at 01 02 22](https://github.com/kean/Pulse/assets/53402452/ebbc2d8b-b5f1-495e-a7a2-6b3914ca48d2)
