### PR TITLE
fix: the pending status issue

### DIFF
--- a/Tests/PulseTests/URLSessionProxyDelegateTests.swift
+++ b/Tests/PulseTests/URLSessionProxyDelegateTests.swift
@@ -113,6 +113,45 @@ final class URLSessionProxyDelegateTests: XCTestCase {
         let message = try XCTUnwrap(task.message)
         XCTAssertEqual(message.label, "network")
     }
+    
+    func testProxyDelegateWithCompletionHandlerAsync() async throws {
+        // GIVEN
+        var myDelegate: MockSessionDelegate? = MockSessionDelegate()
+        let delegate = URLSessionProxyDelegate(logger: logger, delegate: myDelegate)
+        let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+
+        // WHEN
+        let dataURL = directory.url.appending(filename: "logs-archive-v2.pulse")
+        try Resources.pulseArchive.write(to: dataURL)
+        let didComplete = expectation(description: "TaskCompleted")
+
+        let (_, _) = try await session.data(from: dataURL)
+        
+        didComplete.fulfill()
+        
+        autoreleasepool {
+            myDelegate = nil // Make sure that proxy delegate retain the real one (like URLSession does)
+        }
+
+        await fulfillment(of: [didComplete], timeout: 5)
+
+        // RECORD
+        let tasks = try store.allTasks()
+        let task = try XCTUnwrap(tasks.first)
+
+        // THEN
+        XCTAssertEqual(tasks.count, 1)
+
+        XCTAssertEqual(task.url, dataURL.absoluteString)
+        XCTAssertEqual(task.host, nil)
+        XCTAssertEqual(task.httpMethod, "GET")
+        XCTAssertNil(task.errorDomain)
+        XCTAssertEqual(task.errorCode, 0)
+        XCTAssertEqual(task.requestState, NetworkTaskEntity.State.success.rawValue)
+
+        let message = try XCTUnwrap(task.message)
+        XCTAssertEqual(message.label, "network")
+    }
 
     func testForwardingOfUnimplementedMethod() throws {
         // GIVEN


### PR DESCRIPTION
# Description

This pull request proposes a solution for requests with 'Pending' status that never ends.

## Issue

The issue arises when using `dataTask(with:completionHandler:)` with a non-nil `completionHandler`. In this case, the delegate method `urlSession(:task:didCompleteWithError:)` will not be called. Apple's documentation describes this behavior.

> The completion handler will call when the load request is complete. This handler is executed on the delegate queue.
> 
> If you pass nil, only the session delegate methods are called when the task completes, making this method equivalent to the [dataTask(with:)](https://developer.apple.com/documentation/foundation/urlsession/1410592-datatask) method.
>
> [Source](https://developer.apple.com/documentation/foundation/urlsession/1407613-datatask)

The description does not explicitly convey the behavior, but it provides some context.

## Solution

The idea is to move the completion of a network task to `urlSession(:task:didFinishCollecting:)` method, by copying the implementation of `urlSession(:task:didCompleteWithError:)`.

As the next step, I would like to kindly request your professional opinion regarding the potential implementation of the `urlSession(:task:didCompleteWithError:)` method for use in the `urlSession(:task:didFinishCollecting:)` operation. Your valuable insights on this matter would be greatly appreciated.

# Connected issues and discussions:
- https://github.com/kean/Pulse/issues/212
- https://github.com/kean/Pulse/discussions/112

# Bonus
This solution solves `async/await` support
- https://github.com/kean/Pulse/issues/113 