### PR TITLE
fix: Text writing direction to handle RTL languages (#114)

### DIFF
--- a/Sources/PulseUI/Helpers/TextHelper.swift
+++ b/Sources/PulseUI/Helpers/TextHelper.swift
@@ -48,12 +48,14 @@ final class TextHelper {
     private let titleParagraphStyle: NSParagraphStyle = {
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.lineSpacing = -6
+        paragraphStyle.baseWritingDirection = .leftToRight
         return paragraphStyle
     }()
 
     private let bodyParagraphStyle: NSParagraphStyle = {
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.lineSpacing = 3
+        paragraphStyle.baseWritingDirection = .leftToRight
         return paragraphStyle
     }()
 


### PR DESCRIPTION
## Overview

This pull request addresses a text alignment issue in right-to-left (RTL) user interfaces within text view, specifically related to text being aligned at the trailing edge of text views. The problem is also detailed in [Issue #114](https://github.com/kean/Pulse/issues/114). 

## Solution

To resolve this, I have implemented a fix by setting the [`baseWritingDirection`](https://developer.apple.com/documentation/uikit/nsparagraphstyle/1527354-basewritingdirection) in the paragraph styles to override the default behavior.

## Considerations

It's important to note that this fix might alter the appearance of logs completely written in RTL languages. However, this change is justified, considering the limitations in Xcode's editor regarding RTL language support, especially when RTL strings are combined with String Interpolation. As a result, string literals, particularly for logging purposes like network logs, are predominantly written in English.

Furthermore, considering network logging specifically, many standards and protocols are inherently in English, including standard headers and their values. This consideration supports the decision to enforce a left-to-right base writing direction for improved readability and consistency in such contexts.

| Before the Fix | After the Fix |
|:---:|:---:|
| ![Simulator Screenshot - iPhone 15 - 2024-01-23 at 21 42 12](https://github.com/kean/Pulse/assets/19166625/f3fddf6e-029d-4f73-b7a3-a8dd6f34848e) | ![Simulator Screenshot - iPhone 15 - 2024-01-23 at 22 01 17](https://github.com/kean/Pulse/assets/19166625/6a75c2a4-18d4-4296-817c-f42cf05dae73) |