### PR TITLE
Add cocoapods action with push step for easier support of cocoapods with new releases

### DIFF
--- a/.github/workflows/cocoapods.yml
+++ b/.github/workflows/cocoapods.yml
@@ -1,0 +1,14 @@
+name: "Pulse Cocoapods support"
+
+on:
+  release:
+    types: [published, edited, released]
+
+jobs:
+  cocoapods-push:
+    name: Push cocoapods spec
+    runs-on: macOS-12
+    steps:
+      - uses: michaelhenry/deploy-to-cocoapods-github-action@1.0.10
+        with:
+          COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}


### PR DESCRIPTION
Related to an issue I reported today with missing versions: #234 

Used simplest approach I can imagine with cocoapods updates. An action on releases trigger.

It's okay if you don't want to use that version and want to modify it somehow or just tell if you already have any kind of action for same process :)

Action requires a secret for COCOAPODS_TRUNK_TOKEN