### PR TITLE
visionOS support

### DIFF
--- a/Pulse.xcodeproj/project.pbxproj
+++ b/Pulse.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 53;
+	objectVersion = 55;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -87,10 +87,10 @@
 		0C70EA812A3F6190000B1071 /* repos.json in Resources */ = {isa = PBXBuildFile; fileRef = 0CDACDE129EC6607007C15CD /* repos.json */; };
 		0C70EA822A3F619A000B1071 /* MockStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF0D5B0296F189500EED9D4 /* MockStore.swift */; };
 		0C70EA832A3F619A000B1071 /* MockTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF0D5AF296F189500EED9D4 /* MockTask.swift */; };
-		0C70EA842A3F61F9000B1071 /* Pulse.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0CF0D542296F14EA00EED9D4 /* Pulse.framework */; };
-		0C70EA852A3F61F9000B1071 /* Pulse.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0CF0D542296F14EA00EED9D4 /* Pulse.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		0C70EA882A3F61F9000B1071 /* PulseUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0CF0D56C296F17CB00EED9D4 /* PulseUI.framework */; };
-		0C70EA892A3F61F9000B1071 /* PulseUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0CF0D56C296F17CB00EED9D4 /* PulseUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		0C70EA842A3F61F9000B1071 /* Pulse.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0CF0D542296F14EA00EED9D4 /* Pulse.framework */; platformFilters = (ios, tvos, watchos, xros, ); };
+		0C70EA852A3F61F9000B1071 /* Pulse.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0CF0D542296F14EA00EED9D4 /* Pulse.framework */; platformFilters = (ios, tvos, watchos, xros, ); settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		0C70EA882A3F61F9000B1071 /* PulseUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0CF0D56C296F17CB00EED9D4 /* PulseUI.framework */; platformFilters = (ios, tvos, watchos, xros, ); };
+		0C70EA892A3F61F9000B1071 /* PulseUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0CF0D56C296F17CB00EED9D4 /* PulseUI.framework */; platformFilters = (ios, tvos, watchos, xros, ); settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		0C7A0DFB297C33F300B4B69D /* ConsoleRouterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7A0DFA297C33F300B4B69D /* ConsoleRouterView.swift */; };
 		0C7A0E00297C51CE00B4B69D /* ConsoleListOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7A0DFF297C51CE00B4B69D /* ConsoleListOptions.swift */; };
 		0C7A0E02297CE71400B4B69D /* FormattersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C7A0E01297CE71400B4B69D /* FormattersTests.swift */; };
@@ -2202,11 +2202,23 @@
 		};
 		0C70EA872A3F61F9000B1071 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
+			platformFilters = (
+				ios,
+				tvos,
+				watchos,
+				xros,
+			);
 			target = 0CF0D541296F14EA00EED9D4 /* Pulse */;
 			targetProxy = 0C70EA862A3F61F9000B1071 /* PBXContainerItemProxy */;
 		};
 		0C70EA8B2A3F61F9000B1071 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
+			platformFilters = (
+				ios,
+				tvos,
+				watchos,
+				xros,
+			);
 			target = 0CF0D56B296F17CB00EED9D4 /* PulseUI */;
 			targetProxy = 0C70EA8A2A3F61F9000B1071 /* PBXContainerItemProxy */;
 		};
@@ -2760,12 +2772,12 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.kean.pulse-demo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator watchos watchsimulator";
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator watchos watchsimulator xros xrsimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,7";
 			};
 			name = Debug;
 		};
@@ -2804,13 +2816,13 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.github.kean.pulse-demo";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator watchos watchsimulator";
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator watchos watchsimulator xros xrsimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = PULSE_MOCK_INCLUDED;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,7";
 			};
 			name = Release;
 		};
@@ -2937,8 +2949,11 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = auto;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator xros xrsimulator";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 7;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -2971,7 +2986,10 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = auto;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator xros xrsimulator";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 7;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -3004,9 +3022,12 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = auto;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator xros xrsimulator";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 7;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -3038,8 +3059,11 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SDKROOT = auto;
 				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "appletvos appletvsimulator iphoneos iphonesimulator macosx watchos watchsimulator xros xrsimulator";
+				SUPPORTS_MACCATALYST = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 7;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};

--- a/Sources/Pulse/LoggerStore/LoggerStore+Info.swift
+++ b/Sources/Pulse/LoggerStore/LoggerStore+Info.swift
@@ -113,7 +113,7 @@ private func getAppIcon() -> Data? {
     return Graphics.encode(thumbnail)
 }
 
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
 import UIKit
 
 func getDeviceId() -> UUID? {

--- a/Sources/PulseUI/Extensions/Foundation+Extensions.swift
+++ b/Sources/PulseUI/Extensions/Foundation+Extensions.swift
@@ -16,7 +16,7 @@ extension Character {
     }
 }
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 extension AttributedString {
     init(_ string: String, _ configure: (inout AttributeContainer) -> Void) {
         var attributes = AttributeContainer()

--- a/Sources/PulseUI/Extensions/NSAttributedString+Extensions.swift
+++ b/Sources/PulseUI/Extensions/NSAttributedString+Extensions.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
 extension NSAttributedString {
     func getLines() -> [NSAttributedString] {

--- a/Sources/PulseUI/Extensions/SwiftUI+Extensions.swift
+++ b/Sources/PulseUI/Extensions/SwiftUI+Extensions.swift
@@ -5,7 +5,7 @@
 import SwiftUI
 import Combine
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 extension Color {
     static var separator: Color { Color(UXColor.separator) }
     static var secondaryFill: Color { Color(UXColor.secondarySystemFill) }
@@ -45,7 +45,7 @@ extension ContentSizeCategory {
     }
 }
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
 
 enum Keyboard {
     static var isHidden: AnyPublisher<Bool, Never> {
@@ -77,7 +77,7 @@ extension View {
 extension Backport {
     @ViewBuilder
     func presentationDetents(_ detents: Set<PresentationDetent>) -> some View {
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         if #available(iOS 16, *) {
             let detents = detents.map { (detent)-> SwiftUI.PresentationDetent in
                 switch detent {
@@ -114,7 +114,7 @@ extension Backport {
 extension View {
     func inlineNavigationTitle(_ title: String) -> some View {
         self.navigationTitle(title)
-#if os(iOS)
+#if os(iOS) || os(visionOS)
             .navigationBarTitleDisplayMode(.inline)
 #endif
     }

--- a/Sources/PulseUI/Features/Console/ConsoleEnvironment.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleEnvironment.swift
@@ -102,7 +102,7 @@ final class ConsoleEnvironment: ObservableObject {
         store.removeAll()
         index.clear()
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         runHapticFeedback(.success)
 #endif
     }

--- a/Sources/PulseUI/Features/Console/ConsoleView-ios.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleView-ios.swift
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
 
 import SwiftUI
 import CoreData
@@ -27,7 +27,7 @@ public struct ConsoleView: View {
         }
     }
 
-    @available(iOS 15, *)
+    @available(iOS 15, visionOS 1.0, *)
     private var contents: some View {
         ConsoleListView()
             .navigationTitle(environment.title)
@@ -53,7 +53,7 @@ public struct ConsoleView: View {
         return copy
     }
 
-    @available(iOS 15, *)
+    @available(iOS 15, visionOS 1.0, *)
     @ViewBuilder private var trailingNavigationBarItems: some View {
         Button(action: { environment.router.isShowingShareStore = true }) {
             Image(systemName: "square.and.arrow.up")

--- a/Sources/PulseUI/Features/Console/List/ConsoleListContentView.swift
+++ b/Sources/PulseUI/Features/Console/List/ConsoleListContentView.swift
@@ -7,7 +7,7 @@ import Pulse
 import Combine
 import SwiftUI
 
-@available(iOS 15, macOS 13, *)
+@available(iOS 15, macOS 13, visionOS 1.0, *)
 struct ConsoleListContentView: View {
     @EnvironmentObject var viewModel: ConsoleListViewModel
 
@@ -18,7 +18,7 @@ struct ConsoleListContentView: View {
 #endif
 
     var body: some View {
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         if !viewModel.pins.isEmpty, !viewModel.isShowingFocusedEntities {
             ConsoleListPinsSectionView(viewModel: viewModel)
             if !viewModel.entities.isEmpty {
@@ -27,7 +27,7 @@ struct ConsoleListContentView: View {
         }
 #endif
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
         if let sections = viewModel.sections, !sections.isEmpty {
             ForEach(sections, id: \.name) {
                 ConsoleListGroupedSectionView(section: $0, viewModel: viewModel)
@@ -54,7 +54,7 @@ struct ConsoleListContentView: View {
                 let objectID = entity.objectID
                 ConsoleEntityCell(entity: entity)
                     .id(objectID)
-#if os(iOS)
+#if os(iOS) || os(visionOS)
                     .onAppear { viewModel.onAppearCell(with: objectID) }
                     .onDisappear { viewModel.onDisappearCell(with: objectID) }
 #endif
@@ -80,7 +80,7 @@ struct ConsoleListContentView: View {
                     .foregroundColor(.secondary)
             }
             .buttonStyle(.plain)
-#if os(iOS)
+#if os(iOS) || os(visionOS)
             .listRowSeparator(.hidden, edges: .bottom)
 #endif
         }
@@ -143,8 +143,8 @@ struct BottomViewID: Hashable, Identifiable {
 }
 #endif
 
-#if os(iOS) || os(macOS)
-@available(iOS 15, macOS 13, *)
+#if os(iOS) || os(macOS) || os(visionOS)
+@available(iOS 15, macOS 13, visionOS 1.0, *)
 struct ConsoleStaticList: View {
     let entities: [NSManagedObject]
 
@@ -153,7 +153,7 @@ struct ConsoleStaticList: View {
             ForEach(entities, id: \.objectID, content: ConsoleEntityCell.init)
         }
         .listStyle(.plain)
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         .environment(\.defaultMinListRowHeight, 8)
 #endif
     }

--- a/Sources/PulseUI/Features/Console/List/ConsoleListGroupedSectionView.swift
+++ b/Sources/PulseUI/Features/Console/List/ConsoleListGroupedSectionView.swift
@@ -2,14 +2,14 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
 import CoreData
 import Pulse
 import Combine
 import SwiftUI
 
-@available(iOS 15, macOS 13, *)
+@available(iOS 15, macOS 13, visionOS 1.0, *)
 struct ConsoleListGroupedSectionView: View {
     let section: NSFetchedResultsSectionInfo
     @ObservedObject var viewModel: ConsoleListViewModel
@@ -25,7 +25,7 @@ struct ConsoleListGroupedSectionView: View {
         ForEach(prefix, id: \.objectID, content: ConsoleEntityCell.init)
 
         if prefix.count < objects.count {
-#if os(iOS)
+#if os(iOS) || os(visionOS)
             NavigationLink(destination: ConsoleStaticList(entities: objects).inlineNavigationTitle(title)) {
                 PlainListSeeAllView(count: objects.count)
             }

--- a/Sources/PulseUI/Features/Console/List/ConsoleListPinsSectionView.swift
+++ b/Sources/PulseUI/Features/Console/List/ConsoleListPinsSectionView.swift
@@ -2,14 +2,14 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
 
 import CoreData
 import Pulse
 import Combine
 import SwiftUI
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct ConsoleListPinsSectionView: View {
     @ObservedObject var viewModel: ConsoleListViewModel
 

--- a/Sources/PulseUI/Features/Console/List/ConsoleListView.swift
+++ b/Sources/PulseUI/Features/Console/List/ConsoleListView.swift
@@ -2,14 +2,14 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
 import SwiftUI
 import CoreData
 import Pulse
 import Combine
 
-@available(iOS 15, macOS 13, *)
+@available(iOS 15, macOS 13, visionOS 1.0, *)
 struct ConsoleListView: View {
     @EnvironmentObject var environment: ConsoleEnvironment
     @EnvironmentObject var filters: ConsoleFiltersViewModel
@@ -19,7 +19,7 @@ struct ConsoleListView: View {
     }
 }
 
-@available(iOS 15, macOS 13, *)
+@available(iOS 15, macOS 13, visionOS 1.0, *)
 private struct _InternalConsoleListView: View {
     private let environment: ConsoleEnvironment
 
@@ -66,7 +66,7 @@ private struct _InternalConsoleListView: View {
 #endif
                 .onSubmit(of: .search, searchViewModel.value.onSubmitSearch)
                 .disableAutocorrection(true)
-#if os(iOS)
+#if os(iOS) || os(visionOS)
                 .textInputAutocapitalization(.never)
 #endif
         } else {
@@ -74,7 +74,7 @@ private struct _InternalConsoleListView: View {
                 .searchable(text: $searchBarViewModel.text)
                 .onSubmit(of: .search, searchViewModel.value.onSubmitSearch)
                 .disableAutocorrection(true)
-#if os(iOS)
+#if os(iOS) || os(visionOS)
                 .textInputAutocapitalization(.never)
 #endif
         }
@@ -83,8 +83,8 @@ private struct _InternalConsoleListView: View {
 
 #endif
 
-#if os(iOS)
-@available(iOS 15, *)
+#if os(iOS) || os(visionOS)
+@available(iOS 15, visionOS 1.0, *)
 private struct _ConsoleListView: View {
     @Environment(\.isSearching) private var isSearching
     @Environment(\.store) private var store
@@ -133,7 +133,7 @@ private struct _ConsoleListView: View {
 #endif
 
 #if os(macOS)
-@available(iOS 15, macOS 13, *)
+@available(iOS 15, macOS 13, visionOS 1.0, *)
 private struct _ConsoleListView: View {
     @EnvironmentObject private var environment: ConsoleEnvironment
     @EnvironmentObject private var listViewModel: ConsoleListViewModel

--- a/Sources/PulseUI/Features/Console/List/ConsoleListViewModel.swift
+++ b/Sources/PulseUI/Features/Console/List/ConsoleListViewModel.swift
@@ -9,7 +9,7 @@ import Combine
 import SwiftUI
 
 final class ConsoleListViewModel: ConsoleDataSourceDelegate, ObservableObject, ConsoleEntitiesSource {
-#if os(iOS)
+#if os(iOS) || os(visionOS)
     @Published private(set) var visibleEntities: ArraySlice<NSManagedObject> = []
 #else
     var visibleEntities: [NSManagedObject] { entities }
@@ -41,7 +41,7 @@ final class ConsoleListViewModel: ConsoleDataSourceDelegate, ObservableObject, C
 
     let events = PassthroughSubject<ConsoleUpdateEvent, Never>()
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
     /// This exist strictly to workaround List performance issues
     private var scrollPosition: ScrollPosition = .nearTop
     private var visibleEntityCountLimit = ConsoleDataSource.fetchBatchSize
@@ -140,7 +140,7 @@ final class ConsoleListViewModel: ConsoleDataSourceDelegate, ObservableObject, C
 
         entities = dataSource.entities
         sections = dataSource.sections
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         refreshVisibleEntities()
 #endif
         events.send(.refresh)
@@ -149,7 +149,7 @@ final class ConsoleListViewModel: ConsoleDataSourceDelegate, ObservableObject, C
     func dataSource(_ dataSource: ConsoleDataSource, didUpdateWith diff: CollectionDifference<NSManagedObjectID>?) {
         entities = dataSource.entities
         sections = dataSource.sections
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         if scrollPosition == .nearTop {
             refreshVisibleEntities()
         }
@@ -159,7 +159,7 @@ final class ConsoleListViewModel: ConsoleDataSourceDelegate, ObservableObject, C
 
     // MARK: Visible Entities
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
     private enum ScrollPosition {
         case nearTop
         case middle

--- a/Sources/PulseUI/Features/Console/Views/ConsoleContextMenu-ios.swift
+++ b/Sources/PulseUI/Features/Console/Views/ConsoleContextMenu-ios.swift
@@ -2,14 +2,14 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
 
 import SwiftUI
 import CoreData
 import Pulse
 import Combine
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct ConsoleContextMenu: View {
     @EnvironmentObject private var environment: ConsoleEnvironment
     @Environment(\.router) private var router
@@ -90,7 +90,7 @@ private struct ConsoleSortByMenu: View {
 }
 #endif
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 import SwiftUI
 
 struct ConsoleGroupByMenu: View {

--- a/Sources/PulseUI/Features/Console/Views/ConsoleEntityCell.swift
+++ b/Sources/PulseUI/Features/Console/Views/ConsoleEntityCell.swift
@@ -7,7 +7,7 @@ import SwiftUI
 import Pulse
 import CoreData
 
-@available(iOS 15, macOS 13, *)
+@available(iOS 15, macOS 13, visionOS 1.0, *)
 struct ConsoleEntityCell: View {
     let entity: NSManagedObject
 
@@ -27,14 +27,14 @@ struct ConsoleEntityCell: View {
     }
 }
 
-@available(iOS 15, macOS 13, *)
+@available(iOS 15, macOS 13, visionOS 1.0, *)
 private struct _ConsoleMessageCell: View {
     let message: LoggerMessageEntity
 
     @State private var shareItems: ShareItems?
 
     var body: some View {
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         let cell = ConsoleMessageCell(message: message, isDisclosureNeeded: true)
             .background(NavigationLink("", destination: ConsoleMessageDetailsView(message: message)).opacity(0))
 #elseif os(macOS)
@@ -47,7 +47,7 @@ private struct _ConsoleMessageCell: View {
         }
 #endif
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
         cell.swipeActions(edge: .leading, allowsFullSwipe: true) {
             PinButton(viewModel: .init(message)).tint(.pink)
         }
@@ -59,7 +59,7 @@ private struct _ConsoleMessageCell: View {
         .contextMenu {
             ContextMenu.MessageContextMenu(message: message, shareItems: $shareItems)
         }
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         .sheet(item: $shareItems, content: ShareView.init)
 #else
         .popover(item: $shareItems, attachmentAnchor: .point(.leading), arrowEdge: .leading) { ShareView($0) }
@@ -70,7 +70,7 @@ private struct _ConsoleMessageCell: View {
     }
 }
 
-@available(iOS 15, macOS 13, *)
+@available(iOS 15, macOS 13, visionOS 1.0, *)
 private struct _ConsoleTaskCell: View {
     let task: NetworkTaskEntity
     @State private var shareItems: ShareItems?
@@ -78,7 +78,7 @@ private struct _ConsoleTaskCell: View {
     @Environment(\.store) private var store
 
     var body: some View {
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         let cell = ConsoleTaskCell(task: task, isDisclosureNeeded: true)
             .background(NavigationLink("", destination: NetworkInspectorView(task: task)).opacity(0))
 #elseif os(macOS)
@@ -90,13 +90,13 @@ private struct _ConsoleTaskCell: View {
         }
 #endif
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
         cell.swipeActions(edge: .leading, allowsFullSwipe: true) {
             PinButton(viewModel: .init(task)).tint(.pink)
         }
         .swipeActions(edge: .trailing, allowsFullSwipe: true) {
             Button(action: {
-#if os(iOS)
+#if os(iOS) || os(visionOS)
                 shareItems = ShareService.share(task, as: .html, store: store)
 #else
                 sharedTask = task
@@ -106,13 +106,13 @@ private struct _ConsoleTaskCell: View {
             }.tint(.blue)
         }
         .contextMenu {
-#if os(iOS)
+#if os(iOS) || os(visionOS)
             ContextMenu.NetworkTaskContextMenuItems(task: task, sharedItems: $shareItems)
 #else
             ContextMenu.NetworkTaskContextMenuItems(task: task, sharedTask: $sharedTask)
 #endif
         }
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         .sheet(item: $shareItems, content: ShareView.init)
 #else
         .popover(item: $sharedTask, attachmentAnchor: .point(.leading), arrowEdge: .leading) { ShareNetworkTaskView(task: $0) }

--- a/Sources/PulseUI/Features/Console/Views/ConsoleMessageCell.swift
+++ b/Sources/PulseUI/Features/Console/Views/ConsoleMessageCell.swift
@@ -7,7 +7,7 @@ import Pulse
 import CoreData
 import Combine
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct ConsoleMessageCell: View {
     let message: LoggerMessageEntity
     var isDisclosureNeeded = false
@@ -38,14 +38,14 @@ struct ConsoleMessageCell: View {
         HStack {
             Text(title)
                 .lineLimit(1)
-#if os(iOS)
+#if os(iOS) || os(visionOS)
                 .font(ConsoleConstants.fontInfo.weight(.medium))
 #else
                 .font(ConsoleConstants.fontTitle.weight(.medium))
 #endif
                 .foregroundColor(titleColor)
             Spacer()
-#if os(macOS) || os(iOS)
+#if os(macOS) || os(iOS) || os(visionOS)
             PinView(message: message)
 #endif
             HStack(spacing: 3) {
@@ -115,7 +115,7 @@ extension Color {
 }
 
 #if DEBUG
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct ConsoleMessageCell_Previews: PreviewProvider {
     static var previews: some View {
         ConsoleMessageCell(message: try! LoggerStore.mock.allMessages()[0])
@@ -135,7 +135,7 @@ struct ConsoleConstants {
     static let fontTitle = Font.caption
     static let fontInfo = Font.caption
     static let fontBody = Font.body
-#elseif os(iOS)
+#elseif os(iOS) || os(visionOS)
     static let fontTitle = Font.subheadline.monospacedDigit()
     static let fontInfo = Font.caption.monospacedDigit()
     static let fontBody = Font.callout

--- a/Sources/PulseUI/Features/Console/Views/ConsoleRouterView.swift
+++ b/Sources/PulseUI/Features/Console/Views/ConsoleRouterView.swift
@@ -36,8 +36,8 @@ struct ConsoleRouterView: View {
     }
 }
 
-#if os(iOS)
-@available(iOS 15, *)
+#if os(iOS) || os(visionOS)
+@available(iOS 15, visionOS 1.0, *)
 extension ConsoleRouterView {
     var contents: some View {
         Text("").invisible()

--- a/Sources/PulseUI/Features/Console/Views/ConsoleTaskCell.swift
+++ b/Sources/PulseUI/Features/Console/Views/ConsoleTaskCell.swift
@@ -7,7 +7,7 @@ import Pulse
 import Combine
 import CoreData
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct ConsoleTaskCell: View {
     @ObservedObject var task: NetworkTaskEntity
     var isDisclosureNeeded = false
@@ -28,7 +28,7 @@ struct ConsoleTaskCell: View {
 #if !os(macOS)
             details
 #endif
-#if os(iOS)
+#if os(iOS) || os(visionOS)
             requestHeaders
 #endif
         }
@@ -61,7 +61,7 @@ struct ConsoleTaskCell: View {
             details
 #endif
             Spacer()
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
             PinView(task: task)
 #endif
 #if !os(watchOS)
@@ -106,7 +106,7 @@ struct ConsoleTaskCell: View {
             Spacer()
             time
         }
-#elseif os(iOS)
+#elseif os(iOS) || os(visionOS)
         infoText
             .lineLimit(1)
             .font(ConsoleConstants.fontInfo)
@@ -174,7 +174,7 @@ private let titleSpacing: CGFloat = 20
 private let titleSpacing: CGFloat? = nil
 #endif
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct MockBadgeView: View {
     var body: some View {
         Text("MOCK")
@@ -216,7 +216,7 @@ private struct ConsoleProgressText: View {
 }
 
 #if DEBUG
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct ConsoleTaskCell_Previews: PreviewProvider {
     static var previews: some View {
         ConsoleTaskCell(task: LoggerStore.preview.entity(for: .login))

--- a/Sources/PulseUI/Features/Console/Views/ConsoleToolbarView.swift
+++ b/Sources/PulseUI/Features/Console/Views/ConsoleToolbarView.swift
@@ -2,15 +2,15 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
 import SwiftUI
 import Pulse
 import CoreData
 import Combine
 
-#if os(iOS)
-@available(iOS 15, *)
+#if os(iOS) || os(visionOS)
+@available(iOS 15, visionOS 1.0, *)
 struct ConsoleToolbarView: View {
     @EnvironmentObject private var environment: ConsoleEnvironment
 
@@ -177,7 +177,7 @@ private struct ConsoleModeButton: View {
 #endif
 }
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct ConsoleListOptionsView: View {
     @EnvironmentObject private var filters: ConsoleFiltersViewModel
 

--- a/Sources/PulseUI/Features/Filters/Cells/ConsoleSearchLogLevelsCell.swift
+++ b/Sources/PulseUI/Features/Filters/Cells/ConsoleSearchLogLevelsCell.swift
@@ -62,7 +62,7 @@ struct ConsoleSearchLogLevelsCell: View {
             ForEach(LoggerStore.Level.allCases, id: \.self) { level in
                 HStack {
                     Checkbox(level.name.capitalized, isOn: binding(forLevel: level))
-#if os(iOS)
+#if os(iOS) || os(visionOS)
                     Circle()
                         .frame(width: 8, height: 8)
                         .foregroundColor(Color.textColor(for: level))

--- a/Sources/PulseUI/Features/Filters/Cells/ConsoleSearchTimePeriodCell.swift
+++ b/Sources/PulseUI/Features/Filters/Cells/ConsoleSearchTimePeriodCell.swift
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
 import SwiftUI
 import Pulse

--- a/Sources/PulseUI/Features/Filters/ConsoleFiltersView.swift
+++ b/Sources/PulseUI/Features/Filters/ConsoleFiltersView.swift
@@ -6,17 +6,17 @@ import SwiftUI
 import Pulse
 import Combine
 
-@available(iOS 15, macOS 13, *)
+@available(iOS 15, macOS 13, visionOS 1.0, *)
 struct ConsoleFiltersView: View {
     @EnvironmentObject var environment: ConsoleEnvironment // important: reloads mode
     @EnvironmentObject var viewModel: ConsoleFiltersViewModel
 
     var body: some View {
-#if os(iOS) || os(watchOS) || os(tvOS)
+#if os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
         Form {
             form
         }
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         .navigationBarItems(leading: buttonReset)
 #endif
 #else
@@ -63,7 +63,7 @@ struct ConsoleFiltersView: View {
             labelsSection
         }
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
         timePeriodSection
 #endif
     }
@@ -76,7 +76,7 @@ struct ConsoleFiltersView: View {
 
 // MARK: - ConsoleFiltersView (Sections)
 
-@available(iOS 15, macOS 13, *)
+@available(iOS 15, macOS 13, visionOS 1.0, *)
 extension ConsoleFiltersView {
     var sessionsSection: some View {
         ConsoleSection(isDividerHidden: true, header: {
@@ -86,7 +86,7 @@ extension ConsoleFiltersView {
         })
     }
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
     var timePeriodSection: some View {
         ConsoleSection(header: {
             ConsoleSectionHeader(icon: "calendar", title: "Time Period", filter: $viewModel.criteria.shared.dates)
@@ -124,7 +124,7 @@ extension ConsoleFiltersView {
 #if DEBUG
 import CoreData
 
-@available(iOS 15, macOS 13, *)
+@available(iOS 15, macOS 13, visionOS 1.0, *)
 struct ConsoleFiltersView_Previews: PreviewProvider {
     static var previews: some View {
 #if os(macOS)
@@ -156,7 +156,7 @@ struct ConsoleFiltersView_Previews: PreviewProvider {
     }
 }
 
-@available(iOS 15, macOS 13, *)
+@available(iOS 15, macOS 13, visionOS 1.0, *)
 private func makePreview(isOnlyNetwork: Bool) -> some View {
     let store = LoggerStore.mock
     let entities: [NSManagedObject] = try! isOnlyNetwork ? store.allTasks() : store.allMessages()

--- a/Sources/PulseUI/Features/Filters/Views/ConsoleDomainsSelectionView.swift
+++ b/Sources/PulseUI/Features/Filters/Views/ConsoleDomainsSelectionView.swift
@@ -6,7 +6,7 @@ import SwiftUI
 import Pulse
 import Combine
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct ConsoleDomainsSelectionView: View {
     @ObservedObject var viewModel: ConsoleFiltersViewModel
     @EnvironmentObject private var index: LoggerStoreIndex

--- a/Sources/PulseUI/Features/Filters/Views/ConsoleLabelsSelectionView.swift
+++ b/Sources/PulseUI/Features/Filters/Views/ConsoleLabelsSelectionView.swift
@@ -6,7 +6,7 @@ import SwiftUI
 import Pulse
 import Combine
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct ConsoleLabelsSelectionView: View {
     @ObservedObject var viewModel: ConsoleFiltersViewModel
     @EnvironmentObject private var index: LoggerStoreIndex

--- a/Sources/PulseUI/Features/Filters/Views/ConsoleSearchListSelectionView.swift
+++ b/Sources/PulseUI/Features/Filters/Views/ConsoleSearchListSelectionView.swift
@@ -5,7 +5,7 @@
 import SwiftUI
 import Pulse
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct ConsoleSearchListSelectionView<Data: RandomAccessCollection, ID: Hashable, Label: View>: View {
     let title: String
     let items: Data
@@ -14,7 +14,7 @@ struct ConsoleSearchListSelectionView<Data: RandomAccessCollection, ID: Hashable
     let description: (Data.Element) -> String
     @ViewBuilder let label: (Data.Element) -> Label
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
     var limit = 6
 #else
     var limit = 3
@@ -88,7 +88,7 @@ struct ConsoleSearchListSelectionView<Data: RandomAccessCollection, ID: Hashable
 #if os(tvOS)
         .frame(width: 800)
 #endif
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always))
         .disableAutocorrection(true)
 #else
@@ -136,7 +136,7 @@ struct ConsoleSearchListSelectionView<Data: RandomAccessCollection, ID: Hashable
 }
 
 #if DEBUG
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct ConsoleSearchListSelectionView_Previews: PreviewProvider {
     static var previews: some View {
         ConsoleSearchListSelectionViewDemo()
@@ -144,7 +144,7 @@ struct ConsoleSearchListSelectionView_Previews: PreviewProvider {
     }
 }
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 private struct ConsoleSearchListSelectionViewDemo: View {
     @State private var selection: Set<String>  = []
 

--- a/Sources/PulseUI/Features/Filters/Views/ConsoleSearchSectionHeader.swift
+++ b/Sources/PulseUI/Features/Filters/Views/ConsoleSearchSectionHeader.swift
@@ -50,7 +50,7 @@ struct ConsoleSectionHeader: View {
             }
         }.buttonStyle(.plain)
     }
-#elseif os(iOS)
+#elseif os(iOS) || os(visionOS)
     var body: some View {
         HStack {
             Text(title)

--- a/Sources/PulseUI/Features/Filters/Views/ConsoleSessionsPickerView.swift
+++ b/Sources/PulseUI/Features/Filters/Views/ConsoleSessionsPickerView.swift
@@ -6,7 +6,7 @@ import SwiftUI
 import Pulse
 import CoreData
 
-@available(iOS 15, macOS 13, *)
+@available(iOS 15, macOS 13, visionOS 1.0, *)
 struct ConsoleSessionsPickerView: View {
     @Binding var selection: Set<UUID>
     @State private var isShowingPicker = false
@@ -19,7 +19,7 @@ struct ConsoleSessionsPickerView: View {
 #endif
 
     var body: some View {
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         NavigationLink(destination: SessionPickerView(selection: $selection)) {
             InfoRow(title: "Sessions", details: selectedSessionTitle)
         }

--- a/Sources/PulseUI/Features/Filters/Views/DateRangePicker.swift
+++ b/Sources/PulseUI/Features/Filters/Views/DateRangePicker.swift
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
 import SwiftUI
 import CoreData
@@ -23,7 +23,7 @@ struct DateRangePicker: View {
     }
 #else
     var body: some View {
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         if #available(iOS 16, *) {
             ViewThatFits {
                 horizontal
@@ -73,7 +73,7 @@ struct DateRangePicker: View {
             }
             .buttonStyle(.plain)
             .foregroundColor(.red)
-#if os(iOS)
+#if os(iOS) || os(visionOS)
             .padding(.trailing, -4)
 #endif
         }

--- a/Sources/PulseUI/Features/Inspector/Cells/NetworkCookiesCell.swift
+++ b/Sources/PulseUI/Features/Inspector/Cells/NetworkCookiesCell.swift
@@ -5,7 +5,7 @@
 import SwiftUI
 import Pulse
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct NetworkCookiesCell: View {
     let viewModel: NetworkCookiesCellViewModel
 
@@ -29,7 +29,7 @@ struct NetworkCookiesCell: View {
     }
 }
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct NetworkCookiesCellViewModel {
     let title: String
     let details: String
@@ -55,7 +55,7 @@ private func getCookies(from headers: [String: String]?, url: URL?) -> [HTTPCook
     return HTTPCookie.cookies(withResponseHeaderFields: headers, for: url)
 }
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 private func makeAttributedString(for cookies: [HTTPCookie]) -> NSAttributedString {
     guard !cookies.isEmpty else {
         return NSAttributedString(string: "Empty") // Should never happen
@@ -85,7 +85,7 @@ private func makeAttributedString(for cookies: [HTTPCookie]) -> NSAttributedStri
 }
 
 #if DEBUG
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct NetworkCookiesCell_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {

--- a/Sources/PulseUI/Features/Inspector/Cells/NetworkMetricsCell.swift
+++ b/Sources/PulseUI/Features/Inspector/Cells/NetworkMetricsCell.swift
@@ -5,7 +5,7 @@
 import SwiftUI
 import Pulse
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct NetworkMetricsCell: View {
     let task: NetworkTaskEntity
 

--- a/Sources/PulseUI/Features/Inspector/Cells/NetworkRequestStatusCell.swift
+++ b/Sources/PulseUI/Features/Inspector/Cells/NetworkRequestStatusCell.swift
@@ -5,7 +5,7 @@
 import SwiftUI
 import Pulse
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct NetworkRequestStatusCell: View {
     let viewModel: NetworkRequestStatusCellModel
 
@@ -129,7 +129,7 @@ private let spacing: CGFloat? = nil
 #endif
 
 #if DEBUG
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct NetworkRequestStatusCell_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {

--- a/Sources/PulseUI/Features/Inspector/Cells/NetworkRequestStatusSectionView.swift
+++ b/Sources/PulseUI/Features/Inspector/Cells/NetworkRequestStatusSectionView.swift
@@ -5,7 +5,7 @@
 import SwiftUI
 import Pulse
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct NetworkRequestStatusSectionView: View {
     let viewModel: NetworkRequestStatusSectionViewModel
 
@@ -42,7 +42,7 @@ final class NetworkRequestStatusSectionViewModel {
 }
 
 #if DEBUG
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct NetworkRequestStatusSectionView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {

--- a/Sources/PulseUI/Features/Inspector/Cells/NetworkResponseBodyCell.swift
+++ b/Sources/PulseUI/Features/Inspector/Cells/NetworkResponseBodyCell.swift
@@ -5,7 +5,7 @@
 import SwiftUI
 import Pulse
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct NetworkResponseBodyCell: View {
     let viewModel: NetworkResponseBodyCellViewModel
 

--- a/Sources/PulseUI/Features/Inspector/NetworkInspectorView-ios.swift
+++ b/Sources/PulseUI/Features/Inspector/NetworkInspectorView-ios.swift
@@ -2,14 +2,14 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
 
 import SwiftUI
 import CoreData
 import Pulse
 import Combine
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct NetworkInspectorView: View {
     @ObservedObject var task: NetworkTaskEntity
 
@@ -95,7 +95,7 @@ struct NetworkInspectorView: View {
 }
 
 #if DEBUG
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct NetworkInspectorView_Previews: PreviewProvider {
     static var previews: some View {
         Group {

--- a/Sources/PulseUI/Features/Inspector/NetworkInspectorView-shared.swift
+++ b/Sources/PulseUI/Features/Inspector/NetworkInspectorView-shared.swift
@@ -5,7 +5,7 @@
 import SwiftUI
 import Pulse
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 extension NetworkInspectorView {
     @ViewBuilder
     static func makeRequestSection(task: NetworkTaskEntity, isCurrentRequest: Bool) -> some View {

--- a/Sources/PulseUI/Features/MessageDetails/ConsoleMessageDetailsView.swift
+++ b/Sources/PulseUI/Features/MessageDetails/ConsoleMessageDetailsView.swift
@@ -7,11 +7,11 @@
 import SwiftUI
 import Pulse
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct ConsoleMessageDetailsView: View {
     let message: LoggerMessageEntity
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
     var body: some View {
         contents
             .navigationBarTitle("", displayMode: .inline)
@@ -99,7 +99,7 @@ struct ConsoleMessageDetailsView: View {
 }
 
 #if DEBUG
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct ConsoleMessageDetailsView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {

--- a/Sources/PulseUI/Features/MessageDetails/ConsoleMessageMetadataView.swift
+++ b/Sources/PulseUI/Features/MessageDetails/ConsoleMessageMetadataView.swift
@@ -5,7 +5,7 @@
 import SwiftUI
 import Pulse
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct ConsoleMessageMetadataView: View {
     let message: LoggerMessageEntity
 
@@ -50,7 +50,7 @@ private extension String {
 }
 
 #if DEBUG
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct ConsoleMessageMetadataView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {

--- a/Sources/PulseUI/Features/Metrics/NetworkInspectorMetricsView.swift
+++ b/Sources/PulseUI/Features/Metrics/NetworkInspectorMetricsView.swift
@@ -7,7 +7,7 @@ import Pulse
 
 // MARK: - View
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct NetworkInspectorMetricsView: View {
     let viewModel: NetworkInspectorMetricsViewModel
 
@@ -22,7 +22,7 @@ struct NetworkInspectorMetricsView: View {
                 NetworkInspectorTransactionView(viewModel: $0)
             }
         }
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         .listStyle(.insetGrouped)
 #endif
 #if os(macOS)
@@ -53,7 +53,7 @@ final class NetworkInspectorMetricsViewModel {
 // MARK: - Preview
 
 #if DEBUG
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct NetworkInspectorMetricsView_Previews: PreviewProvider {
     static var previews: some View {
 #if os(macOS)

--- a/Sources/PulseUI/Features/Metrics/NetworkInspectorTransactionView.swift
+++ b/Sources/PulseUI/Features/Metrics/NetworkInspectorTransactionView.swift
@@ -6,7 +6,7 @@ import SwiftUI
 import Pulse
 import CoreData
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct NetworkInspectorTransactionView: View {
     @ObservedObject var viewModel: NetworkInspectorTransactionViewModel
 
@@ -34,7 +34,7 @@ struct NetworkInspectorTransactionView: View {
         NetworkRequestInfoCell(viewModel: viewModel.requestViewModel)
     }
     
-    @available(iOS 15, *)
+    @available(iOS 15, visionOS 1.0, *)
     private func transferSizeView(size: NetworkInspectorTransferInfoViewModel) -> some View {
         let font = TextHelper().font(style: .init(role: .subheadline, style: .monospacedDigital, width: .condensed))
         return (Text(Image(systemName: "arrow.down.circle")) +
@@ -90,7 +90,7 @@ final class NetworkInspectorTransactionViewModel: ObservableObject, Identifiable
 }
 
 #if DEBUG
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct NetworkInspectorTransactionView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {

--- a/Sources/PulseUI/Features/Remote/RemoteLoggerEnterPasswordView.swift
+++ b/Sources/PulseUI/Features/Remote/RemoteLoggerEnterPasswordView.swift
@@ -7,7 +7,7 @@ import Network
 import Pulse
 import Combine
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct RemoteLoggerEnterPasswordView: View {
     @ObservedObject var viewModel: RemoteLoggerSettingsViewModel
     @ObservedObject var logger: RemoteLogger = .shared
@@ -34,7 +34,7 @@ struct RemoteLoggerEnterPasswordView: View {
             })
         }
         .inlineNavigationTitle("Enter Password")
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
                 Button("Cancel", role: .cancel) {

--- a/Sources/PulseUI/Features/Remote/RemoteLoggerErrorView.swift
+++ b/Sources/PulseUI/Features/Remote/RemoteLoggerErrorView.swift
@@ -5,7 +5,7 @@
 import SwiftUI
 import Network
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct RemoteLoggerErrorView: View {
     let error: NWError
 
@@ -47,7 +47,7 @@ private struct RemoteLoggerPolicyDeniedView: View {
             Text("Open **Settings** / **Privacy** / **Local Network** and check that the app is listed and the toggle is enabled")
                 .font(.subheadline)
         }
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         Button("Open Settings") {
             UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)
         }
@@ -55,7 +55,7 @@ private struct RemoteLoggerPolicyDeniedView: View {
     }
 }
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 private struct RemoteLoggerNoAuthView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -75,7 +75,7 @@ private struct RemoteLoggerNoAuthView: View {
                 )
                 .padding(.top, 8)
         }
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         Button("Copy Contents") {
             UXPasteboard.general.string = plistContents
         }
@@ -93,7 +93,7 @@ private let plistContents = """
 """
 
 #if DEBUG
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct Previews_RemoteLoggerNoAuthView_Previews: PreviewProvider {
     static var previews: some View {
         Form {

--- a/Sources/PulseUI/Features/Remote/RemoteLoggerSelectedDeviceView.swift
+++ b/Sources/PulseUI/Features/Remote/RemoteLoggerSelectedDeviceView.swift
@@ -6,7 +6,7 @@ import SwiftUI
 import Network
 import Pulse
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct RemoteLoggerSelectedDeviceView: View {
     @ObservedObject var logger: RemoteLogger = .shared
 

--- a/Sources/PulseUI/Features/Remote/RemoteLoggerSettingsView.swift
+++ b/Sources/PulseUI/Features/Remote/RemoteLoggerSettingsView.swift
@@ -8,7 +8,7 @@ import Combine
 import Pulse
 import Network
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct RemoteLoggerSettingsView: View {
     @ObservedObject private var logger: RemoteLogger = .shared
     @ObservedObject var viewModel: RemoteLoggerSettingsViewModel
@@ -64,7 +64,7 @@ struct RemoteLoggerSettingsView: View {
 #if os(macOS)
         .toggleStyle(.switch)
 #endif
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         .padding(.vertical, 2)
 #endif
     }
@@ -108,7 +108,7 @@ struct RemoteLoggerSettingsView: View {
                     Image(systemName: "checkmark")
                         .foregroundColor(.accentColor)
                         .font(.system(size: 15, weight: .medium))
-#if os(iOS)
+#if os(iOS) || os(visionOS)
                         .frame(width: 21, height: 36, alignment: .center)
 #endif
                 }
@@ -130,7 +130,7 @@ struct RemoteLoggerSettingsView: View {
     }
 }
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct RemoteLoggerSettingsRouterView: View {
     @ObservedObject private var logger: RemoteLogger = .shared
     @ObservedObject var viewModel: RemoteLoggerSettingsViewModel
@@ -164,7 +164,7 @@ struct RemoteLoggerSettingsRouterView: View {
 }
 
 #if DEBUG
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct RemoteLoggerSettingsView_Previews: PreviewProvider {
     static var previews: some View {
 #if os(macOS)

--- a/Sources/PulseUI/Features/Search/ConsoleSearchListContentView.swift
+++ b/Sources/PulseUI/Features/Search/ConsoleSearchListContentView.swift
@@ -2,19 +2,19 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
 import SwiftUI
 import Pulse
 import CoreData
 import Combine
 
-@available(iOS 15, macOS 13, *)
+@available(iOS 15, macOS 13, visionOS 1.0, *)
 struct ConsoleSearchListContentView: View {
     @EnvironmentObject private var viewModel: ConsoleSearchViewModel
 
     var body: some View {
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         ConsoleSearchToolbar()
             .listRowBackground(Color.clear)
             .listRowSeparator(.hidden, edges: .top)
@@ -38,7 +38,7 @@ struct ConsoleSearchListContentView: View {
             .background(Color.accentColor)
             .cornerRadius(8)
         }
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         .listRowSeparator(.hidden)
 #endif
         .listRowBackground(Color.separator.opacity(0.2))
@@ -47,12 +47,12 @@ struct ConsoleSearchListContentView: View {
     }
 }
 
-@available(iOS 15, macOS 13, *)
+@available(iOS 15, macOS 13, visionOS 1.0, *)
 struct ConsoleSearchResultsListContentView: View {
     @EnvironmentObject private var viewModel: ConsoleSearchViewModel
 
     var body: some View {
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         if !viewModel.results.isEmpty {
             PlainListGroupSeparator()
         }
@@ -62,7 +62,7 @@ struct ConsoleSearchResultsListContentView: View {
             ConsoleSearchResultView(viewModel: result, isSeparatorNeeded: !viewModel.parameters.terms.isEmpty && !isLast)
         }
         if !viewModel.isSearching && viewModel.hasMore {
-#if os(iOS)
+#if os(iOS) || os(visionOS)
             PlainListGroupSeparator()
 #endif
             Button(action: viewModel.buttonShowMoreResultsTapped) {

--- a/Sources/PulseUI/Features/Search/ConsoleSearchViewModel.swift
+++ b/Sources/PulseUI/Features/Search/ConsoleSearchViewModel.swift
@@ -12,14 +12,14 @@ protocol ConsoleEntitiesSource {
     var entities: [NSManagedObject] { get }
 }
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
 final class ConsoleSearchBarViewModel: ObservableObject {
     @Published var text: String = ""
     @Published var tokens: [ConsoleSearchToken] = []
 }
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 final class ConsoleSearchViewModel: ObservableObject, ConsoleSearchOperationDelegate {
     var isSearchActive: Bool = false {
         didSet {
@@ -96,7 +96,7 @@ final class ConsoleSearchViewModel: ObservableObject, ConsoleSearchOperationDele
 
         self.context = store.newBackgroundContext()
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         searchBar.$text.sink {
             if $0.last == "\t" {
                 DispatchQueue.main.async {
@@ -348,7 +348,7 @@ final class ConsoleSearchViewModel: ObservableObject, ConsoleSearchOperationDele
     }
 }
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct ConsoleSearchResultViewModel: Identifiable {
     var id: ConsoleSearchResultKey { ConsoleSearchResultKey(id: entity.objectID) }
     let entity: NSManagedObject

--- a/Sources/PulseUI/Features/Search/Services/ConsoleSearchFilter+Parsers.swift
+++ b/Sources/PulseUI/Features/Search/Services/ConsoleSearchFilter+Parsers.swift
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
 import Foundation
 import Pulse

--- a/Sources/PulseUI/Features/Search/Services/ConsoleSearchFilter.swift
+++ b/Sources/PulseUI/Features/Search/Services/ConsoleSearchFilter.swift
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
 import Foundation
 import Pulse

--- a/Sources/PulseUI/Features/Search/Services/ConsoleSearchOccurrence.swift
+++ b/Sources/PulseUI/Features/Search/Services/ConsoleSearchOccurrence.swift
@@ -2,14 +2,14 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
 import SwiftUI
 import Pulse
 import CoreData
 import Combine
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 final class ConsoleSearchOccurrence: Identifiable, Equatable, Hashable {
     let id = ConsoleSearchOccurrenceId()
     let scope: ConsoleSearchScope
@@ -38,7 +38,7 @@ final class ConsoleSearchOccurrence: Identifiable, Equatable, Hashable {
 
 private let previewAttibutes = TextHelper().attributes(role: .body2, style: .monospaced)
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 extension ConsoleSearchOccurrence {
     static func makePreview(for match: ConsoleSearchMatch, attributes customAttributes: [NSAttributedString.Key: Any] = [:]) -> AttributedString {
 

--- a/Sources/PulseUI/Features/Search/Services/ConsoleSearchOperation.swift
+++ b/Sources/PulseUI/Features/Search/Services/ConsoleSearchOperation.swift
@@ -2,20 +2,20 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
 import SwiftUI
 import Pulse
 import CoreData
 import Combine
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 protocol ConsoleSearchOperationDelegate: AnyObject {
     func searchOperation(_ operation: ConsoleSearchOperation, didAddResults results: [ConsoleSearchResultViewModel])
     func searchOperationDidFinish(_ operation: ConsoleSearchOperation, hasMore: Bool)
 }
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 final class ConsoleSearchOperation {
     private let parameters: ConsoleSearchParameters
     private var entities: [NSManagedObject]
@@ -257,7 +257,7 @@ struct ConsoleSearchMatch {
     static let limit = 1000
 }
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 final class ConsoleSearchService {
     private let cache = NSCache<NSManagedObjectID, CachedString>()
 

--- a/Sources/PulseUI/Features/Search/Services/ConsoleSearchRecentSearchesStore.swift
+++ b/Sources/PulseUI/Features/Search/Services/ConsoleSearchRecentSearchesStore.swift
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
 import Foundation
 import SwiftUI

--- a/Sources/PulseUI/Features/Search/Services/ConsoleSearchScope.swift
+++ b/Sources/PulseUI/Features/Search/Services/ConsoleSearchScope.swift
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
 import Foundation
 

--- a/Sources/PulseUI/Features/Search/Services/ConsoleSearchSuggestionsService.swift
+++ b/Sources/PulseUI/Features/Search/Services/ConsoleSearchSuggestionsService.swift
@@ -2,14 +2,14 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
 import SwiftUI
 import Pulse
 import CoreData
 import Combine
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct ConsoleSearchSuggestionsViewModel {
     let searches: [ConsoleSearchSuggestion]
     let filters: [ConsoleSearchSuggestion]
@@ -37,7 +37,7 @@ struct ConsoleSearchSuggestionsContext {
     }
 }
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 final class ConsoleNetworkSearchSuggestionsService {
     let recents: ConsoleSearchRecentSearchesStore
     let mode: ConsoleMode
@@ -143,7 +143,7 @@ final class ConsoleNetworkSearchSuggestionsService {
     }
 }
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct ConsoleSearchSuggestion: Identifiable {
     let id = UUID()
     let text: AttributedString

--- a/Sources/PulseUI/Features/Search/Services/ConsoleSearchToken.swift
+++ b/Sources/PulseUI/Features/Search/Services/ConsoleSearchToken.swift
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
 import Foundation
 import SwiftUI

--- a/Sources/PulseUI/Features/Search/Views/ConsoleSearchContextMenu.swift
+++ b/Sources/PulseUI/Features/Search/Views/ConsoleSearchContextMenu.swift
@@ -2,14 +2,14 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
 
 import SwiftUI
 import CoreData
 import Pulse
 import Combine
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct ConsoleSearchContextMenu: View {
     @EnvironmentObject private var viewModel: ConsoleSearchViewModel
 

--- a/Sources/PulseUI/Features/Search/Views/ConsoleSearchResultsSectionView.swift
+++ b/Sources/PulseUI/Features/Search/Views/ConsoleSearchResultsSectionView.swift
@@ -2,14 +2,14 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
 import SwiftUI
 import Pulse
 import CoreData
 import Combine
 
-@available(iOS 15, macOS 13, *)
+@available(iOS 15, visionOS 1.0, macOS 13, *)
 struct ConsoleSearchResultView: View {
     let viewModel: ConsoleSearchResultViewModel
     var limit: Int = 4
@@ -49,7 +49,7 @@ struct ConsoleSearchResultView: View {
             }
 #endif
         }
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         if isSeparatorNeeded {
             PlainListGroupSeparator()
         }
@@ -96,7 +96,7 @@ struct ConsoleSearchResultView: View {
         }
     }
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
     @ViewBuilder
     private static func _makeDestination(for occurrence: ConsoleSearchOccurrence, task: NetworkTaskEntity) -> some View {
         switch occurrence.scope {
@@ -141,7 +141,7 @@ struct ConsoleSearchResultView: View {
     }
 }
 
-@available(iOS 15, macOS 13, *)
+@available(iOS 15, visionOS 1.0, macOS 13, *)
 struct ConsoleSearchResultDetailsView: View {
     let viewModel: ConsoleSearchResultViewModel
 
@@ -155,8 +155,8 @@ struct ConsoleSearchResultDetailsView: View {
     }
 }
 
-#if os(iOS)
-@available(iOS 15, *)
+#if os(iOS) || os(visionOS)
+@available(iOS 15, visionOS 1.0, *)
 struct PlainListGroupSeparator: View {
     var body: some View {
         Rectangle().foregroundColor(.clear) // DIY separator
@@ -168,7 +168,7 @@ struct PlainListGroupSeparator: View {
 }
 #endif
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct PlainListSectionHeader<Content: View>: View {
     var title: String?
     @ViewBuilder let content: () -> Content
@@ -177,7 +177,7 @@ struct PlainListSectionHeader<Content: View>: View {
         contents
             .padding(.top, 8)
             .listRowBackground(Color.separator.opacity(0.2))
-#if os(iOS)
+#if os(iOS) || os(visionOS)
             .listRowSeparator(.hidden)
 #endif
     }
@@ -198,14 +198,14 @@ struct PlainListSectionHeader<Content: View>: View {
     }
 }
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 extension PlainListSectionHeader where Content == Text {
     init(title: String) {
         self.init(title: title, content: { Text(title) })
     }
 }
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct PlainListExpandableSectionHeader<Destination: View>: View {
     let title: String
     let count: Int
@@ -234,7 +234,7 @@ struct PlainListExpandableSectionHeader<Destination: View>: View {
     }
 }
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct PlainListSeeAllView: View {
     let count: Int
 
@@ -247,7 +247,7 @@ struct PlainListSeeAllView: View {
     }
 }
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct PlainListSectionHeaderSeparator: View {
     let title: String
 

--- a/Sources/PulseUI/Features/Search/Views/ConsoleSearchSuggestionView.swift
+++ b/Sources/PulseUI/Features/Search/Views/ConsoleSearchSuggestionView.swift
@@ -2,14 +2,14 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
 import SwiftUI
 import Pulse
 import CoreData
 import Combine
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct ConsoleSearchSuggestionView: View {
     let suggestion: ConsoleSearchSuggestion
     let action: () -> Void

--- a/Sources/PulseUI/Features/Search/Views/ConsoleSearchSuggestionsView.swift
+++ b/Sources/PulseUI/Features/Search/Views/ConsoleSearchSuggestionsView.swift
@@ -2,14 +2,14 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
 import SwiftUI
 import Pulse
 import CoreData
 import Combine
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct ConsoleSearchSuggestionsView: View {
     @EnvironmentObject private var viewModel: ConsoleSearchViewModel
 
@@ -51,7 +51,7 @@ struct ConsoleSearchSuggestionsView: View {
             makeList(with: suggestions.filters)
         }
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         if viewModel.parameters.isEmpty {
             PlainListSectionHeaderSeparator(title: "Scopes").padding(.top, 16)
             ConsoleSearchScopesPicker(viewModel: viewModel)
@@ -70,7 +70,7 @@ struct ConsoleSearchSuggestionsView: View {
                 .font(.subheadline)
             }.buttonStyle(.plain)
         }
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         .listRowInsets(EdgeInsets(top: 8, leading: 0, bottom: 0, trailing: 20))
         .listRowSeparator(.hidden, edges: .bottom)
 #endif
@@ -89,7 +89,7 @@ struct ConsoleSearchSuggestionsView: View {
 }
 
 #if DEBUG
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct Previews_ConsoleSearchSuggestionsView_Previews: PreviewProvider {
     static let environment = ConsoleEnvironment(store: .mock)
 

--- a/Sources/PulseUI/Features/Search/Views/ConsoleSearchToolbar.swift
+++ b/Sources/PulseUI/Features/Search/Views/ConsoleSearchToolbar.swift
@@ -2,14 +2,14 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
 import SwiftUI
 import Pulse
 import CoreData
 import Combine
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct ConsoleSearchToolbar: View {
     @EnvironmentObject private var viewModel: ConsoleSearchViewModel
     @State private var isShowingScopesPicker = false
@@ -46,7 +46,7 @@ struct ConsoleSearchToolbar: View {
     }
 
     private var searchOptionsView: some View {
-#if os(iOS)
+#if os(iOS) || os(visionOS)
             HStack(spacing: 14) {
                 ConsoleSearchContextMenu()
             }
@@ -98,7 +98,7 @@ struct ConsoleSearchStringOptionsView: View {
 }
 #endif
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct ConsoleSearchScopesPicker: View {
     @ObservedObject var viewModel: ConsoleSearchViewModel
 
@@ -120,7 +120,7 @@ struct ConsoleSearchScopesPicker: View {
     }
 }
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct ConsoleSearchPickScopesButton: View {
     @EnvironmentObject var viewModel: ConsoleSearchViewModel
 

--- a/Sources/PulseUI/Features/Sessions/SessionListView.swift
+++ b/Sources/PulseUI/Features/Sessions/SessionListView.swift
@@ -8,9 +8,9 @@ import SwiftUI
 import CoreData
 import Combine
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
-@available(iOS 15, macOS 13, *)
+@available(iOS 15, macOS 13, visionOS 1.0, *)
 struct SessionListView: View {
     @Binding var selection: Set<UUID>
     @Binding var sharedSessions: SelectedSessionsIDs?
@@ -21,7 +21,7 @@ struct SessionListView: View {
     @State private var filterTerm = ""
     @State private var groupedSessions: [(Date, [LoggerSessionEntity])] = []
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
     @Environment(\.editMode) private var editMode
 #endif
     @Environment(\.store) private var store
@@ -82,7 +82,7 @@ struct SessionListView: View {
                 }
             }
         }
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         .listStyle(.plain)
         .searchable(text: $filterTerm)
 #else
@@ -97,7 +97,7 @@ struct SessionListView: View {
             .font(.headline)
             .padding(.vertical, 6)
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
             if editMode?.wrappedValue.isEditing ?? false {
                 Spacer()
 
@@ -163,7 +163,7 @@ struct ConsoleSessionCell: View {
     var isCompact = true
 
     @Environment(\.store) private var store
-#if os(iOS)
+#if os(iOS) || os(visionOS)
     @Environment(\.editMode) private var editMode
 #endif
 
@@ -177,7 +177,7 @@ struct ConsoleSessionCell: View {
             details
         }
         .tag(session.id)
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         .listRowBackground((editMode?.wrappedValue.isEditing ?? false) ? Color.clear : nil)
 #endif
     }

--- a/Sources/PulseUI/Features/Sessions/SessionPickerView.swift
+++ b/Sources/PulseUI/Features/Sessions/SessionPickerView.swift
@@ -8,15 +8,15 @@ import SwiftUI
 import CoreData
 import Combine
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
-@available(iOS 15, macOS 13, *)
+@available(iOS 15, macOS 13, visionOS 1.0, *)
 struct SessionPickerView: View {
     @Binding var selection: Set<UUID>
 
     var body: some View {
         SessionListView(selection: $selection, sharedSessions: .constant(nil))
-#if os(iOS)
+#if os(iOS) || os(visionOS)
             .environment(\.editMode, .constant(.active))
             .inlineNavigationTitle("Sessions")
 #endif

--- a/Sources/PulseUI/Features/Sessions/SessionsView.swift
+++ b/Sources/PulseUI/Features/Sessions/SessionsView.swift
@@ -8,14 +8,14 @@ import SwiftUI
 import CoreData
 import Combine
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
-@available(iOS 15, macOS 13, *)
+@available(iOS 15, macOS 13, visionOS 1.0, *)
 struct SessionsView: View {
     @State private var selection: Set<UUID> = []
     @State private var sharedSessions: SelectedSessionsIDs?
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
     @State private var editMode: EditMode = .inactive
 #endif
 
@@ -35,7 +35,7 @@ struct SessionsView: View {
     @ViewBuilder
     private var content: some View {
         list
-#if os(iOS)
+#if os(iOS) || os(visionOS)
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button(editMode.isEditing ? "Done" : "Edit") {
@@ -65,7 +65,7 @@ struct SessionsView: View {
 
     private var list: some View {
         SessionListView(selection: $selection, sharedSessions: $sharedSessions)
-#if os(iOS)
+#if os(iOS) || os(visionOS)
             .environment(\.editMode, $editMode)
             .onChange(of: selection) {
                 guard !editMode.isEditing, !$0.isEmpty else { return }
@@ -80,7 +80,7 @@ struct SessionsView: View {
 #endif
     }
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
     var bottomBar: some View {
         HStack {
             Button(role: .destructive, action: {
@@ -141,12 +141,12 @@ struct SessionsView: View {
 }
 
 #if DEBUG
-@available(iOS 15.0, macOS 13, *)
+@available(iOS 15.0, macOS 13, visionOS 1.0, *)
 struct Previews_SessionsView_Previews: PreviewProvider {
     static let environment = ConsoleEnvironment(store: .mock)
 
     static var previews: some View {
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         NavigationView {
             SessionsView()
                 .injecting(environment)

--- a/Sources/PulseUI/Features/Settings/SettingsView-ios.swift
+++ b/Sources/PulseUI/Features/Settings/SettingsView-ios.swift
@@ -2,13 +2,13 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
 
 import SwiftUI
 import Pulse
 import UniformTypeIdentifiers
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 public struct SettingsView: View {
     private let store: LoggerStore
     @State private var newHeaderName = ""
@@ -61,7 +61,7 @@ public struct SettingsView: View {
 }
 
 #if DEBUG
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct SettingsView_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {

--- a/Sources/PulseUI/Features/Settings/SettingsView-macos.swift
+++ b/Sources/PulseUI/Features/Settings/SettingsView-macos.swift
@@ -53,7 +53,7 @@ struct UserSettingsView_Previews: PreviewProvider {
 #endif
 #endif
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
 import SwiftUI
 

--- a/Sources/PulseUI/Helpers/DecodingErrorsPreviews.swift
+++ b/Sources/PulseUI/Helpers/DecodingErrorsPreviews.swift
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
 #if DEBUG
 
@@ -29,7 +29,7 @@ struct DecodingErrors_Previews: PreviewProvider {
     @ViewBuilder
     private static func fileViewer(error: NetworkLogger.DecodingError) -> some View {
         let viewer = FileViewer(viewModel: .init(title: "Response", context: .init(contentType: .init(rawValue: "application/json"), originalSize: 1200, error: error), data: { MockJSON.allPossibleValues }))
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         NavigationView {
             viewer
         }

--- a/Sources/PulseUI/Helpers/Parser.swift
+++ b/Sources/PulseUI/Helpers/Parser.swift
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
 import Foundation
 

--- a/Sources/PulseUI/Helpers/ShareItems.swift
+++ b/Sources/PulseUI/Helpers/ShareItems.swift
@@ -68,7 +68,7 @@ enum ShareService {
             let fileURL = directory.write(data: html, extension: "html")
             return ShareItems([fileURL], size: Int64(html.count), cleanup: directory.remove)
         case .pdf:
-#if os(iOS)
+#if os(iOS) || os(visionOS)
             let pdf = (try? TextUtilities.pdf(from: string)) ?? Data()
             let directory = TemporaryDirectory()
             let fileURL = directory.write(data: pdf, extension: "pdf")

--- a/Sources/PulseUI/Helpers/TextHelper.swift
+++ b/Sources/PulseUI/Helpers/TextHelper.swift
@@ -105,7 +105,7 @@ final class TextHelper {
     }
 
     private func scaled(font: UXFont) -> UXFont {
-#if os(iOS) || os(tvOS) || os(watchOS)
+#if os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
         return UIFontMetrics.default.scaledFont(for: font)
 #else
         return font

--- a/Sources/PulseUI/Helpers/TextRenderer.swift
+++ b/Sources/PulseUI/Helpers/TextRenderer.swift
@@ -8,7 +8,7 @@ import CoreData
 import SwiftUI
 import Pulse
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
 import PDFKit
 #endif
 
@@ -448,13 +448,13 @@ struct ConsoleTextRenderer_Previews: PreviewProvider {
                 .previewLayout(.fixed(width: 1160, height: 2000)) // Disable interaction to view it
                 .previewDisplayName("HTML (Raw)")
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
             WebView(data: html, contentType: "application/html")
                 .edgesIgnoringSafeArea([.bottom])
                 .previewDisplayName("HTML")
 #endif
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
             PDFKitRepresentedView(document: PDFDocument(data: try! TextUtilities.pdf(from: string))!)
                 .edgesIgnoringSafeArea([.all])
                 .previewDisplayName("PDF")

--- a/Sources/PulseUI/Helpers/TextUtilities.swift
+++ b/Sources/PulseUI/Helpers/TextUtilities.swift
@@ -8,11 +8,11 @@ import Foundation
 import AppKit
 #endif
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
 import PDFKit
 #endif
 
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
 import UIKit
 #endif
 
@@ -81,7 +81,7 @@ enum TextUtilities {
     }
 
     /// Renders the given attributed string as PDF
-#if os(iOS)
+#if os(iOS) || os(visionOS)
     static func pdf(from string: NSAttributedString) throws -> Data {
         let string = NSMutableAttributedString(attributedString: string)
         string.enumerateAttribute(.font, in: NSRange(location: 0, length: string.length)) { font, range, _ in
@@ -121,7 +121,7 @@ enum TextUtilities {
 }
 
 private var isDarkMode: Bool {
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
     return UIViewController().traitCollection.userInterfaceStyle == .dark
 #elseif os(watchOS)
     return true

--- a/Sources/PulseUI/Helpers/UIKit+Extensions.swift
+++ b/Sources/PulseUI/Helpers/UIKit+Extensions.swift
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
 
 import UIKit
 

--- a/Sources/PulseUI/Helpers/UXKit.swift
+++ b/Sources/PulseUI/Helpers/UXKit.swift
@@ -91,7 +91,7 @@ extension UIColor {
 
 #if os(tvOS)
 typealias UXTextView = UITextView
-#elseif os(iOS)
+#elseif os(iOS) || os(visionOS)
 typealias UXTextView = UITextView
 typealias UXPasteboard = UIPasteboard
 #endif
@@ -126,7 +126,7 @@ extension UXColor {
 
 // MARK: - NSTextView
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
 extension UITextView {
     var isAutomaticLinkDetectionEnabled: Bool {
         get { dataDetectorTypes.contains(.link) }
@@ -139,11 +139,23 @@ extension UITextView {
         }
     }
 }
+#endif
 
+#if os(iOS)
 func runHapticFeedback(_ type: UINotificationFeedbackGenerator.FeedbackType = .success) {
     UINotificationFeedbackGenerator().notificationOccurred(type)
 }
 #endif
+
+#if os(visionOS)
+enum VisionHapticFeedabackTypePlaceholder {
+    case success, warning, error
+}
+func runHapticFeedback(_ type: VisionHapticFeedabackTypePlaceholder = .success) {
+    // Do nothing
+}
+#endif
+
 
 #if os(macOS)
 extension NSTextView {
@@ -168,7 +180,7 @@ func runHapticFeedback(_ type: NSHapticFeedabackTypePlaceholder = .success) {
 #endif
 
 extension Image {
-#if os(iOS) || os(watchOS) || os(tvOS)
+#if os(iOS) || os(watchOS) || os(tvOS) || os(visionOS)
     init(uxImage: UXImage) {
         self.init(uiImage: uxImage)
     }

--- a/Sources/PulseUI/Helpers/WatchConnectivityService-ios.swift
+++ b/Sources/PulseUI/Helpers/WatchConnectivityService-ios.swift
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
 
 import CoreData
 import Combine
@@ -59,7 +59,7 @@ extension LoggerStore {
 
 #endif
 
-#if os(iOS) || os(watchOS)
+#if os(iOS) || os(watchOS) || os(visionOS)
 extension WatchConnectivityService {
     static let pulseDocumentMarkerKey = "com.github.kean.pulse.imported-store-marker"
 }

--- a/Sources/PulseUI/Views/Checkbox.swift
+++ b/Sources/PulseUI/Views/Checkbox.swift
@@ -9,7 +9,7 @@ struct Checkbox<Label: View>: View {
     let label: () -> Label
 
     var body: some View {
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         Button(action: { isOn.toggle() }) {
             HStack {
                 Image(systemName: isOn ? "checkmark.circle.fill" : "circle")

--- a/Sources/PulseUI/Views/ContextMenus.swift
+++ b/Sources/PulseUI/Views/ContextMenus.swift
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
 import SwiftUI
 import Pulse
@@ -10,7 +10,7 @@ import Combine
 import CoreData
 
 enum ContextMenu {
-    @available(iOS 15, *)
+    @available(iOS 15, visionOS 1.0, *)
     struct MessageContextMenu: View {
         let message: LoggerMessageEntity
 
@@ -52,7 +52,7 @@ enum ContextMenu {
             Section {
                 PinButton(viewModel: .init(message)).tint(.pink)
             }
-#if os(iOS)
+#if os(iOS) || os(visionOS)
             ButtonOpenOnMac(entity: message)
 #endif
         }
@@ -60,7 +60,7 @@ enum ContextMenu {
 
     struct NetworkTaskContextMenuItems: View {
         let task: NetworkTaskEntity
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         @Binding private(set) var sharedItems: ShareItems?
 #else
         @Binding private(set) var sharedTask: NetworkTaskEntity?
@@ -70,7 +70,7 @@ enum ContextMenu {
 
         var body: some View {
             Section {
-#if os(iOS)
+#if os(iOS) || os(visionOS)
                 ContextMenu.NetworkTaskShareMenu(task: task, shareItems: $sharedItems)
 #else
                 Button(action: { sharedTask = task }) {
@@ -79,7 +79,7 @@ enum ContextMenu {
 #endif
                 ContextMenu.NetworkTaskCopyMenu(task: task)
             }
-#if os(iOS)
+#if os(iOS) || os(visionOS)
             if !isDetailsView {
                 NetworkTaskFilterMenu(task: task)
             }
@@ -89,7 +89,7 @@ enum ContextMenu {
                     PinButton(viewModel: .init(message))
                 }
             }
-#if os(iOS)
+#if os(iOS) || os(visionOS)
             ButtonOpenOnMac(entity: task)
 #endif
         }
@@ -258,8 +258,8 @@ struct StringSearchOptionsMenu: View {
     }
 }
 
-#if os(iOS)
-@available(iOS 15, *)
+#if os(iOS) || os(visionOS)
+@available(iOS 15, visionOS 1.0, *)
 struct OpenOnMacOverlay: View {
     let entity: NSManagedObject
     @ObservedObject var logger: RemoteLogger = .shared
@@ -320,7 +320,7 @@ struct AttributedStringShareMenu: View {
         Button(action: { shareItems = ShareService.share(string(), as: .html) }) {
             Label("Share as HTML", systemImage: "square.and.arrow.up")
         }
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         Button(action: { shareItems = ShareService.share(string(), as: .pdf) }) {
             Label("Share as PDF", systemImage: "square.and.arrow.up")
         }

--- a/Sources/PulseUI/Views/FileViewer.swift
+++ b/Sources/PulseUI/Views/FileViewer.swift
@@ -8,7 +8,7 @@ import Pulse
 struct FileViewer: View {
     @ObservedObject var viewModel: FileViewerViewModel
 
-#if os(iOS) || os(watchOS) || os(macOS)
+#if os(iOS) || os(watchOS) || os(macOS) || os(visionOS)
     var body: some View {
         contents
     }
@@ -28,7 +28,7 @@ struct FileViewer: View {
             ScrollView {
                 ImageViewer(viewModel: viewModel)
             }
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
         case .pdf(let document):
             PDFKitRepresentedView(document: document)
                 .edgesIgnoringSafeArea(.all)
@@ -75,7 +75,7 @@ private struct PreviewContainer<Content: View>: View {
     @ViewBuilder var contents: () -> Content
 
     var body: some View {
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         NavigationView {
             contents()
         }

--- a/Sources/PulseUI/Views/FileViewerViewModel.swift
+++ b/Sources/PulseUI/Views/FileViewerViewModel.swift
@@ -7,7 +7,7 @@ import CoreData
 import Pulse
 import Combine
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 import PDFKit
 #endif
 
@@ -36,7 +36,7 @@ final class FileViewerViewModel: ObservableObject {
     enum Contents {
         case image(ImagePreviewViewModel)
         case other(RichTextViewModel)
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
         case pdf(PDFDocument)
 #endif
     }
@@ -56,7 +56,7 @@ final class FileViewerViewModel: ObservableObject {
     }
 
     private func makePDF(data: Data) -> Contents? {
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
         if let pdf = PDFDocument(data: data) {
             return .pdf(pdf)
         }

--- a/Sources/PulseUI/Views/LoggerStoreSizeChart.swift
+++ b/Sources/PulseUI/Views/LoggerStoreSizeChart.swift
@@ -6,7 +6,7 @@ import SwiftUI
 import Pulse
 import Charts
 
-@available(iOS 16.0, tvOS 16.0, macOS 13.0, watchOS 9.0, *)
+@available(iOS 16.0, tvOS 16.0, macOS 13.0, watchOS 9.0, visionOS 1.0, *)
 struct LoggerStoreSizeChart: View {
     let info: LoggerStore.Info
     let sizeLimit: Int64?
@@ -63,14 +63,14 @@ struct LoggerStoreSizeChart: View {
     }
 }
 
-@available(iOS 16.0, tvOS 16.0, macOS 13.0, watchOS 9.0, *)
+@available(iOS 16.0, tvOS 16.0, macOS 13.0, watchOS 9.0, visionOS 1.0, *)
 private enum Category: String, Hashable, Plottable {
     case messages = "Logs"
     case responses = "Blobs"
     case free = "Free"
 }
 
-@available(iOS 16.0, tvOS 16.0, macOS 13.0, watchOS 9.0, *)
+@available(iOS 16.0, tvOS 16.0, macOS 13.0, watchOS 9.0, visionOS 1.0, *)
 private struct Series: Identifiable {
     let category: Category
     let bytes: Int64
@@ -78,7 +78,7 @@ private struct Series: Identifiable {
 }
 
 #if DEBUG
-@available(iOS 16.0, tvOS 16.0, macOS 13.0, watchOS 9.0, *)
+@available(iOS 16.0, tvOS 16.0, macOS 13.0, watchOS 9.0, visionOS 1.0, *)
 struct LoggerStoreSizeChart_Previews: PreviewProvider {
     static var previews: some View {
         LoggerStoreSizeChart(info: try! LoggerStore.mock.info(), sizeLimit: 512 * 1024)

--- a/Sources/PulseUI/Views/PDFRepresentedView.swift
+++ b/Sources/PulseUI/Views/PDFRepresentedView.swift
@@ -4,7 +4,7 @@
 
 import SwiftUI
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
 import PDFKit
 
 struct PDFKitRepresentedView: UIViewRepresentable {

--- a/Sources/PulseUI/Views/PinButton.swift
+++ b/Sources/PulseUI/Views/PinButton.swift
@@ -8,7 +8,7 @@ import CoreData
 import Pulse
 import Combine
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
 struct PinButton: View {
     @ObservedObject var viewModel: PinButtonViewModel

--- a/Sources/PulseUI/Views/PulseUI+UIKit.swift
+++ b/Sources/PulseUI/Views/PulseUI+UIKit.swift
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
 
 import Foundation
 import UIKit

--- a/Sources/PulseUI/Views/RichTextView/RichTextView.swift
+++ b/Sources/PulseUI/Views/RichTextView/RichTextView.swift
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(macOS) || os(iOS)
+#if os(macOS) || os(iOS) || os(visionOS)
 
 import SwiftUI
 import CoreData
@@ -24,7 +24,7 @@ struct RichTextView: View {
         return copy
     }
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
     var body: some View {
         contents
             .onAppear { viewModel.prepare(searchContext) }
@@ -53,7 +53,7 @@ struct RichTextView: View {
         }
     }
 
-    @available(iOS 15, *)
+    @available(iOS 15, visionOS 1.0, *)
     private struct ContentView: View {
         @ObservedObject var viewModel: RichTextViewModel
         @Environment(\.isSearching) private var isSearching

--- a/Sources/PulseUI/Views/RichTextView/RichTextViewModel.swift
+++ b/Sources/PulseUI/Views/RichTextView/RichTextViewModel.swift
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
 import SwiftUI
 import Pulse
@@ -69,7 +69,7 @@ final class RichTextViewModel: ObservableObject {
         didUpdateMatches(matches, string: textStorage)
         if context.matchIndex < matches.count {
             DispatchQueue.main.async {
-#if os(iOS)
+#if os(iOS) || os(visionOS)
                 self.textView?.layoutManager.allowsNonContiguousLayout = false // Remove this workaround
                 UIView.performWithoutAnimation {
                     self.updateMatchIndex(context.matchIndex)

--- a/Sources/PulseUI/Views/RichTextView/RichTextViewSearchToobar-ios.swift
+++ b/Sources/PulseUI/Views/RichTextView/RichTextViewSearchToobar-ios.swift
@@ -2,11 +2,11 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
 
 import SwiftUI
 
-@available(iOS 15, *)
+@available(iOS 15, visionOS 1.0, *)
 struct RichTextViewSearchToobar: View {
     @ObservedObject var viewModel: RichTextViewModel
 

--- a/Sources/PulseUI/Views/RichTextView/WrappedTextView.swift
+++ b/Sources/PulseUI/Views/RichTextView/WrappedTextView.swift
@@ -2,12 +2,12 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
 import SwiftUI
 import Combine
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
 
 struct WrappedTextView: UIViewRepresentable {
     let viewModel: RichTextViewModel
@@ -128,13 +128,15 @@ private func configureTextView(_ textView: UXTextView) {
     ]
     textView.backgroundColor = .clear
 
-#if os(iOS)
-    textView.keyboardDismissMode = .interactive
+#if os(iOS) || os(visionOS)
     textView.alwaysBounceVertical = true
     textView.autocorrectionType = .no
     textView.autocapitalizationType = .none
     textView.adjustsFontForContentSizeCategory = true
     textView.textContainerInset = UIEdgeInsets(top: 8, left: 10, bottom: 8, right: 10)
+#endif
+#if os(iOS)
+    textView.keyboardDismissMode = .interactive
 #endif
 
 #if os(macOS)

--- a/Sources/PulseUI/Views/ShareStoreView.swift
+++ b/Sources/PulseUI/Views/ShareStoreView.swift
@@ -2,14 +2,14 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS) || os(macOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(watchOS) || os(visionOS)
 
 import SwiftUI
 import CoreData
 import Pulse
 import Combine
 
-@available(iOS 15, macOS 13, watchOS 9, *)
+@available(iOS 15, macOS 13, watchOS 9, visionOS 1.0, *)
 struct ShareStoreView: View {
     /// Preselected sessions.
     var sessions: Set<UUID> = []
@@ -35,7 +35,7 @@ struct ShareStoreView: View {
 
     @ViewBuilder
     private var content: some View {
-#if os(iOS) || os(watchOS)
+#if os(iOS) || os(watchOS) || os(visionOS)
         Form {
             sectionSharingOptions
             sectionShare
@@ -54,7 +54,7 @@ struct ShareStoreView: View {
             }
 #endif
         }
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
         .sheet(item: $viewModel.shareItems) {
             ShareView($0).onCompletion(onDismiss)
         }
@@ -79,7 +79,7 @@ struct ShareStoreView: View {
     private var sectionSharingOptions: some View {
         Section {
             ConsoleSessionsPickerView(selection: $viewModel.sessions)
-#if os(iOS)
+#if os(iOS) || os(visionOS)
             NavigationLink(destination: destinationLogLevels) {
                 InfoRow(title: "Log Levels", details: viewModel.selectedLevelsTitle)
             }
@@ -113,11 +113,11 @@ struct ShareStoreView: View {
         }.inlineNavigationTitle("Log Levels")
     }
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
     private var sectionShare: some View {
         Section {
             Button(action: { viewModel.buttonSharedTapped() }) {
-#if os(iOS)
+#if os(iOS) || os(visionOS)
                 HStack {
                     Spacer()
                     Text(viewModel.isPreparingForSharing ? "Exporting..." : "Share")
@@ -130,7 +130,7 @@ struct ShareStoreView: View {
             }
             .disabled(viewModel.isPreparingForSharing)
             .foregroundColor(.white)
-#if os(iOS)
+#if os(iOS) || os(visionOS)
             .listRowBackground(viewModel.isPreparingForSharing ? Color.accentColor.opacity(0.33) : Color.accentColor)
 #endif
         }
@@ -157,10 +157,10 @@ struct ShareStoreView: View {
 }
 
 #if DEBUG
-@available(iOS 15, macOS 13, watchOS 9, *)
+@available(iOS 15, macOS 13, watchOS 9, visionOS 1.0, *)
 struct ShareStoreView_Previews: PreviewProvider {
     static var previews: some View {
-#if os(iOS)
+#if os(iOS) || os(visionOS)
         NavigationView {
             ShareStoreView(onDismiss: {})
         }

--- a/Sources/PulseUI/Views/ShareStoreViewModel.swift
+++ b/Sources/PulseUI/Views/ShareStoreViewModel.swift
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS) || os(macOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(watchOS) || os(visionOS)
 
 import SwiftUI
 import CoreData

--- a/Sources/PulseUI/Views/ShareView.swift
+++ b/Sources/PulseUI/Views/ShareView.swift
@@ -4,7 +4,7 @@
 
 import SwiftUI
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
 import UIKit
 
 struct ShareView: UIViewControllerRepresentable {

--- a/Sources/PulseUI/Views/TextView.swift
+++ b/Sources/PulseUI/Views/TextView.swift
@@ -4,7 +4,7 @@
 
 import SwiftUI
 
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
 /// A simple text view for rendering attributed strings.
 struct TextView: UIViewRepresentable {
     let string: NSAttributedString
@@ -51,17 +51,17 @@ struct TextView: View {
 }
 #endif
 
-#if os(iOS) || os(macOS) || os(tvOS)
+#if os(iOS) || os(macOS) || os(tvOS) || os(visionOS)
 private func configureTextView(_ textView: UXTextView) {
     textView.isSelectable = true
     textView.backgroundColor = .clear
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
     textView.isEditable = false
     textView.isAutomaticLinkDetectionEnabled = false
 #endif
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
     textView.isScrollEnabled = false
     textView.adjustsFontForContentSizeCategory = true
     textView.textContainerInset = .zero

--- a/Sources/PulseUI/Views/WebView.swift
+++ b/Sources/PulseUI/Views/WebView.swift
@@ -4,7 +4,7 @@
 
 import SwiftUI
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
 
 import WebKit
 import UIKit

--- a/Tests/PulseTests/LoggerStoreTests.swift
+++ b/Tests/PulseTests/LoggerStoreTests.swift
@@ -635,7 +635,7 @@ final class LoggerStoreTests: LoggerStoreBaseTests {
 
     // MARK: - Image Support
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
     func testImageThumbnailsAreStored() throws {
         // GIVEN
         let image = try makeMockImage()

--- a/Tests/PulseUITests/ConsoleSearchOccurrenceTests.swift
+++ b/Tests/PulseUITests/ConsoleSearchOccurrenceTests.swift
@@ -2,7 +2,7 @@
 //
 // Copyright (c) 2020–2023 Alexander Grebenyuk (github.com/kean).
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
 import XCTest
 import Combine

--- a/Tests/PulseUITests/ConsoleSearchTokenTests.swift
+++ b/Tests/PulseUITests/ConsoleSearchTokenTests.swift
@@ -6,7 +6,7 @@ import XCTest
 @testable import Pulse
 @testable import PulseUI
 
-#if os(iOS) || os(macOS)
+#if os(iOS) || os(macOS) || os(visionOS)
 
 final class ConsoleSearchTokenTests: XCTestCase {
     func testStatusCodeFilter() throws {


### PR DESCRIPTION
The current version of the Pulse library does not support the visionOS target, resulting in Xcode generating an error when attempting to build our project with a Pulse dependency for visionOS.

I've decided to fix it. Tested the demo app – works and looks good!

![Simulator Screenshot - Apple Vision Pro - 2024-02-18 at 17 11 43](https://github.com/kean/Pulse/assets/5983656/5049a6d3-5bab-489f-ad96-0f8644e42ad8)
