### PR TITLE
added some form of UIKit Support

### DIFF
--- a/Demo/Integrations/ViewController.swift
+++ b/Demo/Integrations/ViewController.swift
@@ -19,26 +19,32 @@ final class ViewController: UIViewController, UITableViewDataSource, UITableView
         sections = [
             MenuSection(title: "Main", footer: "Demonstartes how to show the entire PulseUI interface (all four tabs)", items: [
                 MenuItem(title: "MainViewController", isPush: false, action: { [unowned self] in
-                    let vc = MainViewController(store: .mock)
+                    let vc = UIConsoleNavigationViewController(store: .mock)
                     self.present(vc, animated: true, completion: nil)
                 }),
                 MenuItem(title: "MainViewController (Fullscreen)", isPush: false, action: { [unowned self] in
-                    let vc = MainViewController(store: .mock)
+                    let vc = UIConsoleNavigationViewController(store: .mock)
                     vc.modalPresentationStyle = .fullScreen
                     self.present(vc, animated: true, completion: nil)
                 })
             ]),
             MenuSection(title: "Components", footer: "Demonstrates how you can push individual PulseUI screens into an existing navigation (UINavigationController or NavigationView)", items: [
                 MenuItem(title: "ConsoleView", action: { [unowned self] in
-                    let vc = UIHostingController(rootView: ConsoleView(store: .mock).closeButtonHidden())
+                    let vc = UIConsoleViewController(store: .mock)
+                    vc.closeButtonHidden()
+                    
                     self.navigationController?.pushViewController(vc, animated: true)
                 }),
                 MenuItem(title: "ConsoleView (Logs)", action: { [unowned self] in
-                    let vc = UIHostingController(rootView: ConsoleView(store: .mock, mode: .logs).closeButtonHidden())
+                    let vc = UIConsoleViewController(store: .mock, mode: .logs)
+                    vc.closeButtonHidden()
+                    
                     self.navigationController?.pushViewController(vc, animated: true)
                 }),
                 MenuItem(title: "ConsoleView (Network)", action: { [unowned self] in
-                    let vc = UIHostingController(rootView: ConsoleView(store: .mock, mode: .network).closeButtonHidden())
+                    let vc = UIConsoleViewController(store: .mock, mode: .network)
+                    vc.closeButtonHidden()
+                    
                     self.navigationController?.pushViewController(vc, animated: true)
                 })
             ]),

--- a/Pulse.xcodeproj/project.pbxproj
+++ b/Pulse.xcodeproj/project.pbxproj
@@ -271,6 +271,7 @@
 		0CFF79DD29EB7A8E00BE767B /* SessionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFF79DB29EB7A8B00BE767B /* SessionListView.swift */; };
 		0CFF79DF29EB7B4300BE767B /* SessionPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFF79DE29EB7B4300BE767B /* SessionPickerView.swift */; };
 		0CFF79E229EC1FA200BE767B /* ImageProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFF79E029EC1F7800BE767B /* ImageProcessor.swift */; };
+		22A72D0F2B8C5E980037B730 /* UIKit-Console-Wrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A72D0E2B8C5E980037B730 /* UIKit-Console-Wrapper.swift */; };
 		E95D6C562B7314E6004D28E4 /* HARDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = E95D6C552B7314E6004D28E4 /* HARDocument.swift */; };
 /* End PBXBuildFile section */
 
@@ -726,6 +727,7 @@
 		0CFF79DB29EB7A8B00BE767B /* SessionListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListView.swift; sourceTree = "<group>"; };
 		0CFF79DE29EB7B4300BE767B /* SessionPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionPickerView.swift; sourceTree = "<group>"; };
 		0CFF79E029EC1F7800BE767B /* ImageProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageProcessor.swift; sourceTree = "<group>"; };
+		22A72D0E2B8C5E980037B730 /* UIKit-Console-Wrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIKit-Console-Wrapper.swift"; sourceTree = "<group>"; };
 		49E82A8526D107A00070244F /* AlamofireIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlamofireIntegration.swift; sourceTree = "<group>"; };
 		49E82A8826D1083D0070244F /* MoyaIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoyaIntegration.swift; sourceTree = "<group>"; };
 		E95D6C552B7314E6004D28E4 /* HARDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HARDocument.swift; sourceTree = "<group>"; };
@@ -1384,6 +1386,7 @@
 				0CBEF6A429DF69E800132FB3 /* ConsoleView.swift */,
 				0CF0D60A296F189600EED9D4 /* ConsoleEnvironment.swift */,
 				0CECF63C2996BE12000F9CCD /* ConsoleDataSource.swift */,
+				22A72D0E2B8C5E980037B730 /* UIKit-Console-Wrapper.swift */,
 			);
 			path = Console;
 			sourceTree = "<group>";
@@ -2070,6 +2073,7 @@
 				0C11EAE92971EBEE0059786A /* MockTask.swift in Sources */,
 				0C63A388297A432500F6A6A5 /* ConsoleSearchToolbar.swift in Sources */,
 				0CF0D66E296F189600EED9D4 /* NetworkCURLCell.swift in Sources */,
+				22A72D0F2B8C5E980037B730 /* UIKit-Console-Wrapper.swift in Sources */,
 				0C31FFB9298211AF002A7D64 /* ConsoleEntityDetailsView.swift in Sources */,
 				0CF0D625296F189600EED9D4 /* PlaceholderView.swift in Sources */,
 				0CFF79DF29EB7B4300BE767B /* SessionPickerView.swift in Sources */,

--- a/Sources/PulseUI/Features/Console/UIKit-Console-Wrapper.swift
+++ b/Sources/PulseUI/Features/Console/UIKit-Console-Wrapper.swift
@@ -5,6 +5,7 @@
 //  Created by Morris Richman on 2/25/24.
 //
 
+#if canImport(UIKit)
 import UIKit
 import SwiftUI
 import CoreData
@@ -62,3 +63,5 @@ public func UIConsoleNavigationViewController(store: LoggerStore = .shared, mode
     
     return UIHostingController(rootView: view)
 }
+
+#endif

--- a/Sources/PulseUI/Features/Console/UIKit-Console-Wrapper.swift
+++ b/Sources/PulseUI/Features/Console/UIKit-Console-Wrapper.swift
@@ -1,0 +1,60 @@
+//
+//  UIKit-Console-Wrapper.swift
+//
+//
+//  Created by Morris Richman on 2/25/24.
+//
+
+import UIKit
+import SwiftUI
+import CoreData
+import Pulse
+import Combine
+
+
+/// Initializes the console view controller
+///
+/// - parameters:
+///   - store: The store to display. By default, `LoggerStore/shared`.
+///   - mode: The console mode. By default, ``ConsoleMode/all``. If you change
+///   the mode to ``ConsoleMode/network``, the console will only display the
+public func UIConsoleViewController(store: LoggerStore = .shared, mode: ConsoleMode = .all) -> UIHostingController<ConsoleView> {
+    UIHostingController(rootView: ConsoleView(store: store, mode: mode))
+}
+
+extension UIHostingController<ConsoleView> {
+    public func closeButtonHidden(_ isHidden: Bool = true) {
+        self.rootView = self.rootView.closeButtonHidden(isHidden)
+    }
+}
+
+@available(iOS 16.0, *)
+/// Initializes the console view controller with swiftui navigation built in
+///
+/// - parameters:
+///   - store: The store to display. By default, `LoggerStore/shared`.
+///   - mode: The console mode. By default, ``ConsoleMode/all``. If you change
+///   the mode to ``ConsoleMode/network``, the console will only display the
+public func UIConsoleNavigationViewController(store: LoggerStore = .shared, mode: ConsoleMode = .all) -> UIHostingController<NavigationStack<NavigationPath, ConsoleView>> {
+    
+    let view = NavigationStack {
+        ConsoleView(store: store, mode: mode)
+    }
+    
+    return UIHostingController(rootView: view)
+}
+
+/// Initializes the console view controller with swiftui navigation built in
+///
+/// - parameters:
+///   - store: The store to display. By default, `LoggerStore/shared`.
+///   - mode: The console mode. By default, ``ConsoleMode/all``. If you change
+///   the mode to ``ConsoleMode/network``, the console will only display the
+public func UIConsoleNavigationViewController(store: LoggerStore = .shared, mode: ConsoleMode = .all) -> UIHostingController<NavigationView<ConsoleView>> {
+    
+    let view = NavigationView {
+        ConsoleView(store: store, mode: mode)
+    }
+    
+    return UIHostingController(rootView: view)
+}

--- a/Sources/PulseUI/Features/Console/UIKit-Console-Wrapper.swift
+++ b/Sources/PulseUI/Features/Console/UIKit-Console-Wrapper.swift
@@ -24,6 +24,7 @@ public func UIConsoleViewController(store: LoggerStore = .shared, mode: ConsoleM
 
 extension UIHostingController<ConsoleView> {
 #if os(iOS)
+    /// Changes the default close button visibility.
     public func closeButtonHidden(_ isHidden: Bool = true) {
         self.rootView = self.rootView.closeButtonHidden(isHidden)
     }

--- a/Sources/PulseUI/Features/Console/UIKit-Console-Wrapper.swift
+++ b/Sources/PulseUI/Features/Console/UIKit-Console-Wrapper.swift
@@ -23,12 +23,15 @@ public func UIConsoleViewController(store: LoggerStore = .shared, mode: ConsoleM
 }
 
 extension UIHostingController<ConsoleView> {
+#if os(iOS)
     public func closeButtonHidden(_ isHidden: Bool = true) {
         self.rootView = self.rootView.closeButtonHidden(isHidden)
     }
+#endif
 }
 
 @available(iOS 16.0, *)
+@available(tvOS 16.0, *)
 /// Initializes the console view controller with swiftui navigation built in
 ///
 /// - parameters:

--- a/Sources/PulseUI/Features/Console/UIKit-Console-Wrapper.swift
+++ b/Sources/PulseUI/Features/Console/UIKit-Console-Wrapper.swift
@@ -24,7 +24,7 @@ public func UIConsoleViewController(store: LoggerStore = .shared, mode: ConsoleM
 
 extension UIHostingController<ConsoleView> {
 #if os(iOS)
-    /// Changes the default close button visibility.
+    /// Changes the default close button visibility. 
     public func closeButtonHidden(_ isHidden: Bool = true) {
         self.rootView = self.rootView.closeButtonHidden(isHidden)
     }

--- a/Sources/PulseUI/Features/Console/UIKit-Console-Wrapper.swift
+++ b/Sources/PulseUI/Features/Console/UIKit-Console-Wrapper.swift
@@ -12,7 +12,6 @@ import CoreData
 import Pulse
 import Combine
 
-
 /// Initializes the console view controller
 ///
 /// - parameters:


### PR DESCRIPTION
I added 3 functions for UIKit:

1. `UIConsoleViewController` is a function that neatly wraps `ConsoleView` into UIKit, and yes the `closeButtonHidden` modifier still works (ie. `vc. closeButtonHidden(true)`
2. `UIConsoleNavigationViewController` is two different functions that support navigation before ios 16 and ios 16+. It is the same as `UIConsoleViewController`, but with a navigation wrapper.