### PR TITLE
Fix task description not being used with URLSessionProxyDelegate

### DIFF
--- a/Sources/Pulse/LoggerStore/LoggerStore.swift
+++ b/Sources/Pulse/LoggerStore/LoggerStore.swift
@@ -422,6 +422,7 @@ extension LoggerStore {
         entity.responseContentType = event.response?.contentType?.type
         let isFailure = event.error != nil || event.response?.isSuccess == false
         entity.requestState = (isFailure ? NetworkTaskEntity.State.failure : .success).rawValue
+        entity.taskDescription = event.taskDescription
 
         // Populate response/request data
         let responseContentType = event.response?.contentType


### PR DESCRIPTION
We are using the URLSessionProxyDelegate to record network tasks to pulse. #254 introduced task description support for custom titles, however this was not working with URLSessionProxyDelegate as the URLSessionDataTask didn't have a taskDescription in `func urlSession(_ session: URLSession, didCreateTask task: URLSessionTask)` as it is added directly after creation like below:

```swift
dataTask = self.dataTask(with: request) { data, response, error in
   
}
dataTask?.taskDescription = taskDescription
dataTask?.resume()
```