### PR TITLE
fix: wrong background context for exporting and filtering entities

### DIFF
--- a/Pulse.xcodeproj/xcshareddata/xcschemes/Pulse Demo Companion iOS App.xcscheme
+++ b/Pulse.xcodeproj/xcshareddata/xcschemes/Pulse Demo Companion iOS App.xcscheme
@@ -49,6 +49,12 @@
             ReferencedContainer = "container:Pulse.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-com.apple.CoreData.ConcurrencyDebug 1"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Pulse.xcodeproj/xcshareddata/xcschemes/Pulse Demo Companion watchOS App.xcscheme
+++ b/Pulse.xcodeproj/xcshareddata/xcschemes/Pulse Demo Companion watchOS App.xcscheme
@@ -63,6 +63,12 @@
             ReferencedContainer = "container:Pulse.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-com.apple.CoreData.ConcurrencyDebug 1"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Pulse.xcodeproj/xcshareddata/xcschemes/Pulse Demo iOS.xcscheme
+++ b/Pulse.xcodeproj/xcshareddata/xcschemes/Pulse Demo iOS.xcscheme
@@ -49,6 +49,12 @@
             ReferencedContainer = "container:Pulse.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-com.apple.CoreData.ConcurrencyDebug 1"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Pulse.xcodeproj/xcshareddata/xcschemes/Pulse Demo macOS.xcscheme
+++ b/Pulse.xcodeproj/xcshareddata/xcschemes/Pulse Demo macOS.xcscheme
@@ -50,6 +50,12 @@
             ReferencedContainer = "container:Pulse.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-com.apple.CoreData.ConcurrencyDebug 1"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Pulse.xcodeproj/xcshareddata/xcschemes/Pulse Demo tvOS.xcscheme
+++ b/Pulse.xcodeproj/xcshareddata/xcschemes/Pulse Demo tvOS.xcscheme
@@ -50,6 +50,12 @@
             ReferencedContainer = "container:Pulse.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-com.apple.CoreData.ConcurrencyDebug 1"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Pulse.xcodeproj/xcshareddata/xcschemes/Pulse Integration Examples iOS.xcscheme
+++ b/Pulse.xcodeproj/xcshareddata/xcschemes/Pulse Integration Examples iOS.xcscheme
@@ -50,6 +50,12 @@
             ReferencedContainer = "container:Pulse.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-com.apple.CoreData.ConcurrencyDebug 1"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Sources/Pulse/LoggerStore/LoggerStore.swift
+++ b/Sources/Pulse/LoggerStore/LoggerStore.swift
@@ -931,12 +931,12 @@ extension LoggerStore {
         defer { try? target.close() }
 
         // Remove unwanted messages
-        backgroundContext.performAndWait {
+        target.backgroundContext.performAndWait {
             try? target._removeUnwantedExportableContent(for: options)
         }
 
         // Copy required blobs
-        backgroundContext.performAndWait {
+        target.backgroundContext.performAndWait {
             try? _exportBlobs(to: target)
         }
 


### PR DESCRIPTION
# Context

In my project, I enabled the "-com.apple.CoreData.ConcurrencyDebug" option, and the app started crashing. I was puzzled by this because everything seemed fine at first glance.

After some investigation, I realized the issue: we are creating a new entity for the store while using a shared store and its background context to remove unnecessary session entities. This mismatch in the queue is causing the crash.

Afterward, I added CoreData debug flags to the demo targets to identify and resolve the issue more quickly and easily.