### PR TITLE
Order exported items by creation date

### DIFF
--- a/Sources/PulseUI/Views/ShareStoreViewModel.swift
+++ b/Sources/PulseUI/Views/ShareStoreViewModel.swift
@@ -109,6 +109,10 @@ import Combine
             store.backgroundContext.perform {
                 let request = NSFetchRequest<LoggerMessageEntity>(entityName: "\(LoggerMessageEntity.self)")
                 request.predicate = options.predicate // important: contains sessions
+
+                let sortDescriptor = NSSortDescriptor(key: "createdAt", ascending: true)
+                request.sortDescriptors = [sortDescriptor]
+
                 let result = Result(catching: { try store.backgroundContext.fetch(request) })
                 continuation.resume(with: result)
             }


### PR DESCRIPTION
In our project, we noticed that the logs could sometimes end up in a scrambled order during export, especially if they were created pretty much simultaneously (down to a few milliseconds). 

After some investigation, it seems like explicitly adding the sort descriptor seems to have resolved our issue, so I'd like to propose this update to the tool as well.