### PR TITLE
Avoid `MainActor.assumeIsolated`

### DIFF
--- a/Sources/PulseUI/Features/Console/ConsoleDataSource.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleDataSource.swift
@@ -17,7 +17,6 @@ protocol ConsoleDataSourceDelegate: AnyObject {
     func dataSource(_ dataSource: ConsoleDataSource, didUpdateWith diff: CollectionDifference<NSManagedObjectID>?)
 }
 
-@MainActor
 final class ConsoleDataSource: NSObject, NSFetchedResultsControllerDelegate {
     weak var delegate: ConsoleDataSourceDelegate?
 
@@ -103,7 +102,7 @@ final class ConsoleDataSource: NSObject, NSFetchedResultsControllerDelegate {
         controller.delegate = controllerDelegate
     }
 
-    func bind(_ filters: ConsoleFiltersViewModel) {
+    @MainActor func bind(_ filters: ConsoleFiltersViewModel) {
         cancellables = []
         filters.$options.sink { [weak self] in
             self?.predicate = $0
@@ -135,16 +134,12 @@ final class ConsoleDataSource: NSObject, NSFetchedResultsControllerDelegate {
     
     // MARK: NSFetchedResultsControllerDelegate
 
-    nonisolated func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
-        MainActor.assumeIsolated {
-            delegate?.dataSource(self, didUpdateWith: nil)
-        }
+    func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
+        delegate?.dataSource(self, didUpdateWith: nil)
     }
 
-    nonisolated func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChangeContentWith diff: CollectionDifference<NSManagedObjectID>) {
-        MainActor.assumeIsolated {
-            delegate?.dataSource(self, didUpdateWith: diff)
-        }
+    func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChangeContentWith diff: CollectionDifference<NSManagedObjectID>) {
+        delegate?.dataSource(self, didUpdateWith: diff)
     }
 
     // MARK: Predicate


### PR DESCRIPTION
`MainActor.assumeIsolated` should generally be avoided since it's a last-resort method to get around the concurrency system, but also it's limited to newer platform versions. I assume it wasn't intentional to limit PulseUI's supported platforms this way?

`'assumeIsolated(_:file:line:)' is only available in iOS 17.0 or newer`