### PR TITLE
Fix UI bug in macOS scroll view

### DIFF
--- a/Sources/PulseUI/Features/Console/List/ConsoleListContentView.swift
+++ b/Sources/PulseUI/Features/Console/List/ConsoleListContentView.swift
@@ -89,7 +89,9 @@ struct ConsoleListContentView: View {
 #if os(macOS)
     private func registerNowMode<T: View>(for list: T) -> some View {
         list.onChange(of: viewModel.entities) { entities in
-            guard isNowEnabled else { return }
+            /// From empty to 1 causes a bug on macOS where the first cell falls behind the overflow.
+            /// Check for count == 1 to always animate to the first inserted item.
+            guard isNowEnabled || entities.count == 1 else { return }
 
             withAnimation {
                 proxy.scrollTo(BottomViewID(), anchor: .top)


### PR DESCRIPTION
When testing on macOS, I noticed an issue with the list when a first item is injected:

![CleanShot 2024-06-24 at 19 55 13@2x](https://github.com/kean/Pulse/assets/4329185/5846df54-3fc1-46a4-82e4-aaf205fdcda0)

This is likely caused by the `ScrollViewProxy` and a simple animate for every first item fixes the issue. It's fine either way to scroll to the first item since the user is not somewhere in the middle of a large list.