### PR TITLE
Public accessor to server-related methods

### DIFF
--- a/Sources/Pulse/LoggerStore/LoggerStore.swift
+++ b/Sources/Pulse/LoggerStore/LoggerStore.swift
@@ -347,7 +347,7 @@ extension LoggerStore {
     }
 
     /// Handles event created by the current store and dispatches it to observers.
-    func handle(_ event: Event) {
+    public func handle(_ event: Event) {
         guard let event = configuration.willHandleEvent(event) else {
             return
         }

--- a/Sources/Pulse/RemoteLogger/RemoteLogger-Connection.swift
+++ b/Sources/Pulse/RemoteLogger/RemoteLogger-Connection.swift
@@ -11,13 +11,13 @@ import OSLog
 import Pulse
 #endif
 
-protocol RemoteLoggerConnectionDelegate: AnyObject {
+public protocol RemoteLoggerConnectionDelegate: AnyObject {
     func connection(_ connection: RemoteLogger.Connection, didChangeState newState: NWConnection.State)
     func connection(_ connection: RemoteLogger.Connection, didReceiveEvent event: RemoteLogger.Connection.Event)
 }
 
-extension RemoteLogger {
-    final class Connection {
+public extension RemoteLogger {
+    public final class Connection {
         var endpoint: NWEndpoint { connection.endpoint }
         private let connection: NWConnection
         private var buffer = Data()
@@ -31,14 +31,15 @@ extension RemoteLogger {
             self.init(NWConnection(to: endpoint, using: parameters))
         }
 
-        init(_ connection: NWConnection) {
+        public init(_ connection: NWConnection, delegate: RemoteLoggerConnectionDelegate? = nil) {
             self.connection = connection
+            self.delegate = delegate
 
             let isLogEnabled = UserDefaults.standard.bool(forKey: "com.github.kean.pulse.debug")
             self.log = isLogEnabled ? OSLog(subsystem: "com.github.kean.pulse", category: "RemoteLogger") : .disabled
         }
-
-        func start(on queue: DispatchQueue) {
+        
+        public func start(on queue: DispatchQueue) {
             connection.stateUpdateHandler = { [weak self] state in
                 guard let self = self else { return }
                 DispatchQueue.main.async {
@@ -49,15 +50,15 @@ extension RemoteLogger {
             connection.start(queue: queue)
         }
 
-        enum Event {
+        public enum Event {
             case packet(Packet)
             case error(Error)
             case completed
         }
 
-        struct Packet {
-            let code: UInt8
-            let body: Data
+        public struct Packet {
+            public let code: UInt8
+            public let body: Data
         }
 
         private func receive() {
@@ -130,7 +131,7 @@ extension RemoteLogger {
             }
         }
         
-        func send(code: UInt8, data: Data) {
+        public func send(code: UInt8, data: Data) {
             do {
                 let data = try encode(code: code, body: data)
                 let log = self.log
@@ -144,7 +145,7 @@ extension RemoteLogger {
             }
         }
 
-        func send<T: Encodable>(code: UInt8, entity: T) {
+        public func send<T: Encodable>(code: UInt8, entity: T) {
             do {
                 let data = try JSONEncoder().encode(entity)
                 send(code: code, data: data)
@@ -206,7 +207,7 @@ extension RemoteLogger {
             }
         }
         
-        func cancel() {
+        public func cancel() {
             connection.cancel()
         }
     }

--- a/Sources/Pulse/RemoteLogger/RemoteLogger-Protocol.swift
+++ b/Sources/Pulse/RemoteLogger/RemoteLogger-Protocol.swift
@@ -8,8 +8,8 @@ import Network
 import Pulse
 #endif
 
-extension RemoteLogger {
-    enum PacketCode: UInt8, Equatable {
+public extension RemoteLogger {
+    public enum PacketCode: UInt8, Equatable {
         // Handshake
         case clientHello = 0 // PacketClientHello
         case serverHello = 1 // ServerHelloResponse
@@ -44,7 +44,7 @@ extension RemoteLogger {
         init() {}
     }
     
-    struct PacketNetworkMessage {
+    public struct PacketNetworkMessage {
         private struct Manifest: Codable {
             let messageSize: UInt32
             let requestBodySize: UInt32
@@ -83,7 +83,7 @@ extension RemoteLogger {
             return data
         }
         
-        static func decode(_ data: Data) throws -> LoggerStore.Event.NetworkTaskCompleted {
+        public static func decode(_ data: Data) throws -> LoggerStore.Event.NetworkTaskCompleted {
             guard data.count >= Manifest.size else {
                 throw PacketParsingError.notEnoughData // Should never happen
             }
@@ -195,8 +195,12 @@ extension RemoteLogger {
         case openTaskDetails
     }
 
-    struct ServerHelloResponse: Codable {
+    public struct ServerHelloResponse: Codable {
         let version: String
+        
+        public init(version: String) {
+            self.version = version
+        }
     }
 }
 

--- a/Sources/Pulse/RemoteLogger/RemoteLogger.swift
+++ b/Sources/Pulse/RemoteLogger/RemoteLogger.swift
@@ -322,7 +322,7 @@ public final class RemoteLogger: ObservableObject, RemoteLoggerConnectionDelegat
 
         openConnection(to: server, passcode: passcode)
     }
-
+    
     private func connectionDidTimeout(isProtected: Bool) {
         os_log("Connection did timeout", log: log)
         connectionCompletion?(.failure(self.connectionError ?? .unknown(isProtected: isProtected)))
@@ -341,7 +341,7 @@ public final class RemoteLogger: ObservableObject, RemoteLoggerConnectionDelegat
     }
 
     private func saveServer(named name: String) {
-        os_log("Save server  %{private}@", log: log, name)
+        os_log("Save server %{private}@", log: log, name)
         knownServers.removeAll(where: { $0 == name })
         knownServers.append(name)
         saveKnownServers()
@@ -371,7 +371,7 @@ public final class RemoteLogger: ObservableObject, RemoteLoggerConnectionDelegat
 
     // MARK: RemoteLoggerConnectionDelegate
 
-    func connection(_ connection: Connection, didChangeState newState: NWConnection.State) {
+    public func connection(_ connection: Connection, didChangeState newState: NWConnection.State) {
         os_log("Connection did change state to %{public}@", log: log, "\(newState)")
 
         switch newState {
@@ -390,7 +390,7 @@ public final class RemoteLogger: ObservableObject, RemoteLoggerConnectionDelegat
         }
     }
 
-    func connection(_ connection: Connection, didReceiveEvent event: Connection.Event) {
+    public func connection(_ connection: Connection, didReceiveEvent event: Connection.Event) {
         switch event {
         case .packet(let packet):
             do {
@@ -730,5 +730,5 @@ extension RemoteLogger.ConnectionState {
 }
 
 extension RemoteLogger {
-    public static let serviceType = "_pulse._tcp"
+    public static var serviceType = "_pulse._tcp"
 }

--- a/Sources/PulseUI/Features/Console/List/ConsoleListView.swift
+++ b/Sources/PulseUI/Features/Console/List/ConsoleListView.swift
@@ -174,8 +174,7 @@ private struct _ConsoleListView: View {
                     } else {
                         ConsoleListContentView(proxy: proxy)
                     }
-                }.scrollContentBackground(.hidden)
-                    .background(Color.black.opacity(0.32))
+                }
             }
             .environment(\.defaultMinListRowHeight, 1)
         }

--- a/Sources/PulseUI/Features/Console/List/ConsoleListView.swift
+++ b/Sources/PulseUI/Features/Console/List/ConsoleListView.swift
@@ -174,7 +174,8 @@ private struct _ConsoleListView: View {
                     } else {
                         ConsoleListContentView(proxy: proxy)
                     }
-                }
+                }.scrollContentBackground(.hidden)
+                    .background(Color.black.opacity(0.32))
             }
             .environment(\.defaultMinListRowHeight, 1)
         }


### PR DESCRIPTION
To allow for setting up a server-side communication with the `RemoteLogger`, I've added `public` attributes to several methods. These are the bare-minimum to potentially set up a custom server for receiving remote logging messages.