### PR TITLE
macOS Session View improvements

### DIFF
--- a/Demo/macOS/Pulse_Demo_macOSApp.swift
+++ b/Demo/macOS/Pulse_Demo_macOSApp.swift
@@ -11,7 +11,6 @@ struct Pulse_Demo_macOSApp: App {
         WindowGroup {
             ConsoleView(store: .demo)
         }
-        .windowStyle(.hiddenTitleBar)
         .windowToolbarStyle(.unified(showsTitle: false))
     }
 }

--- a/Sources/Pulse/LoggerStore/LoggerStore.swift
+++ b/Sources/Pulse/LoggerStore/LoggerStore.swift
@@ -347,7 +347,7 @@ extension LoggerStore {
     }
 
     /// Handles event created by the current store and dispatches it to observers.
-    func handle(_ event: Event) {
+    public func handle(_ event: Event) {
         guard let event = configuration.willHandleEvent(event) else {
             return
         }

--- a/Sources/Pulse/RemoteLogger/RemoteLogger-Connection.swift
+++ b/Sources/Pulse/RemoteLogger/RemoteLogger-Connection.swift
@@ -11,13 +11,13 @@ import OSLog
 import Pulse
 #endif
 
-protocol RemoteLoggerConnectionDelegate: AnyObject {
+public protocol RemoteLoggerConnectionDelegate: AnyObject {
     func connection(_ connection: RemoteLogger.Connection, didChangeState newState: NWConnection.State)
     func connection(_ connection: RemoteLogger.Connection, didReceiveEvent event: RemoteLogger.Connection.Event)
 }
 
-extension RemoteLogger {
-    final class Connection {
+public extension RemoteLogger {
+    public final class Connection {
         var endpoint: NWEndpoint { connection.endpoint }
         private let connection: NWConnection
         private var buffer = Data()
@@ -31,14 +31,15 @@ extension RemoteLogger {
             self.init(NWConnection(to: endpoint, using: parameters))
         }
 
-        init(_ connection: NWConnection) {
+        public init(_ connection: NWConnection, delegate: RemoteLoggerConnectionDelegate? = nil) {
             self.connection = connection
+            self.delegate = delegate
 
             let isLogEnabled = UserDefaults.standard.bool(forKey: "com.github.kean.pulse.debug")
             self.log = isLogEnabled ? OSLog(subsystem: "com.github.kean.pulse", category: "RemoteLogger") : .disabled
         }
-
-        func start(on queue: DispatchQueue) {
+        
+        public func start(on queue: DispatchQueue) {
             connection.stateUpdateHandler = { [weak self] state in
                 guard let self = self else { return }
                 DispatchQueue.main.async {
@@ -49,15 +50,15 @@ extension RemoteLogger {
             connection.start(queue: queue)
         }
 
-        enum Event {
+        public enum Event {
             case packet(Packet)
             case error(Error)
             case completed
         }
 
-        struct Packet {
-            let code: UInt8
-            let body: Data
+        public struct Packet {
+            public let code: UInt8
+            public let body: Data
         }
 
         private func receive() {
@@ -130,7 +131,7 @@ extension RemoteLogger {
             }
         }
         
-        func send(code: UInt8, data: Data) {
+        public func send(code: UInt8, data: Data) {
             do {
                 let data = try encode(code: code, body: data)
                 let log = self.log
@@ -144,7 +145,7 @@ extension RemoteLogger {
             }
         }
 
-        func send<T: Encodable>(code: UInt8, entity: T) {
+        public func send<T: Encodable>(code: UInt8, entity: T) {
             do {
                 let data = try JSONEncoder().encode(entity)
                 send(code: code, data: data)
@@ -206,7 +207,7 @@ extension RemoteLogger {
             }
         }
         
-        func cancel() {
+        public func cancel() {
             connection.cancel()
         }
     }

--- a/Sources/Pulse/RemoteLogger/RemoteLogger-Protocol.swift
+++ b/Sources/Pulse/RemoteLogger/RemoteLogger-Protocol.swift
@@ -8,8 +8,8 @@ import Network
 import Pulse
 #endif
 
-extension RemoteLogger {
-    enum PacketCode: UInt8, Equatable {
+public extension RemoteLogger {
+    public enum PacketCode: UInt8, Equatable {
         // Handshake
         case clientHello = 0 // PacketClientHello
         case serverHello = 1 // ServerHelloResponse
@@ -44,7 +44,7 @@ extension RemoteLogger {
         init() {}
     }
     
-    struct PacketNetworkMessage {
+    public struct PacketNetworkMessage {
         private struct Manifest: Codable {
             let messageSize: UInt32
             let requestBodySize: UInt32
@@ -83,7 +83,7 @@ extension RemoteLogger {
             return data
         }
         
-        static func decode(_ data: Data) throws -> LoggerStore.Event.NetworkTaskCompleted {
+        public static func decode(_ data: Data) throws -> LoggerStore.Event.NetworkTaskCompleted {
             guard data.count >= Manifest.size else {
                 throw PacketParsingError.notEnoughData // Should never happen
             }
@@ -195,8 +195,12 @@ extension RemoteLogger {
         case openTaskDetails
     }
 
-    struct ServerHelloResponse: Codable {
+    public struct ServerHelloResponse: Codable {
         let version: String
+        
+        public init(version: String) {
+            self.version = version
+        }
     }
 }
 

--- a/Sources/Pulse/RemoteLogger/RemoteLogger.swift
+++ b/Sources/Pulse/RemoteLogger/RemoteLogger.swift
@@ -322,7 +322,7 @@ public final class RemoteLogger: ObservableObject, RemoteLoggerConnectionDelegat
 
         openConnection(to: server, passcode: passcode)
     }
-
+    
     private func connectionDidTimeout(isProtected: Bool) {
         os_log("Connection did timeout", log: log)
         connectionCompletion?(.failure(self.connectionError ?? .unknown(isProtected: isProtected)))
@@ -341,7 +341,7 @@ public final class RemoteLogger: ObservableObject, RemoteLoggerConnectionDelegat
     }
 
     private func saveServer(named name: String) {
-        os_log("Save server  %{private}@", log: log, name)
+        os_log("Save server %{private}@", log: log, name)
         knownServers.removeAll(where: { $0 == name })
         knownServers.append(name)
         saveKnownServers()
@@ -371,7 +371,7 @@ public final class RemoteLogger: ObservableObject, RemoteLoggerConnectionDelegat
 
     // MARK: RemoteLoggerConnectionDelegate
 
-    func connection(_ connection: Connection, didChangeState newState: NWConnection.State) {
+    public func connection(_ connection: Connection, didChangeState newState: NWConnection.State) {
         os_log("Connection did change state to %{public}@", log: log, "\(newState)")
 
         switch newState {
@@ -390,7 +390,7 @@ public final class RemoteLogger: ObservableObject, RemoteLoggerConnectionDelegat
         }
     }
 
-    func connection(_ connection: Connection, didReceiveEvent event: Connection.Event) {
+    public func connection(_ connection: Connection, didReceiveEvent event: Connection.Event) {
         switch event {
         case .packet(let packet):
             do {
@@ -730,5 +730,5 @@ extension RemoteLogger.ConnectionState {
 }
 
 extension RemoteLogger {
-    public static let serviceType = "_pulse._tcp"
+    public static var serviceType = "_pulse._tcp"
 }

--- a/Sources/PulseUI/Features/Console/ConsoleView-macos.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleView-macos.swift
@@ -51,7 +51,7 @@ private struct ConsoleMainView: View {
 
     private var contentView: some View {
         ConsoleListView()
-            .frame(minWidth: 200, idealWidth: 400, minHeight: 120, idealHeight: 480)
+            .frame(minWidth: 400, idealWidth: 500, minHeight: 120, idealHeight: 480)
             .toolbar {
                 ToolbarItemGroup(placement: .navigation) {
                     contentToolbarNavigationItems

--- a/Sources/PulseUI/Features/Console/ConsoleView-macos.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleView-macos.swift
@@ -60,18 +60,21 @@ private struct ConsoleMainView: View {
                     Button(action: { isShowingFilters = true }) {
                         Label("Show Filters", systemImage: "line.3.horizontal.decrease.circle")
                     }
+                    .help("Show Filters")
                     .popover(isPresented: $isShowingFilters) {
                         ConsoleFiltersView().frame(width: 300).fixedSize()
                     }
                     Button(action: { isShowingSessions = true }) {
                         Label("Show Sessions", systemImage: "list.clipboard")
                     }
+                    .help("Show Sessions")
                     .popover(isPresented: $isShowingSessions) {
                         SessionsView().frame(width: 300, height: 420)
                     }
                     Button(action: { isShowingSettings = true }) {
                         Label("Show Settings", systemImage: "gearshape")
                     }
+                    .help("Show Settings")
                     .popover(isPresented: $isShowingSettings) {
                         SettingsView().frame(width: 300, height: 420)
                     }
@@ -88,10 +91,11 @@ private struct ConsoleMainView: View {
         if !(environment.store.options.contains(.readonly)) {
             Toggle(isOn: $isNowEnabled) {
                 Image(systemName: "clock")
-            }
+            }.help("Now Mode: Automatically scrolls to the top of the view to display newly incoming network requests.")
             Button(action: { isSharingStore = true }) {
                 Image(systemName: "square.and.arrow.up")
             }
+            .help("Share a session")
             .popover(isPresented: $isSharingStore, arrowEdge: .bottom) {
                 ShareStoreView(onDismiss: {})
                     .frame(width: 240).fixedSize()
@@ -99,6 +103,7 @@ private struct ConsoleMainView: View {
             Button(action: { environment.store.removeAll() }) {
                 Image(systemName: "trash")
             }
+            .help("Clear current session")
         }
     }
 }

--- a/Sources/PulseUI/Features/Console/ConsoleView.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleView.swift
@@ -12,9 +12,9 @@ extension ConsoleView {
     ///
     /// - parameters:
     ///   - store: The store to display. By default, `LoggerStore/shared`.
-    ///   - mode: The console mode. By default, ``ConsoleMode/all``. If you change
-    ///   the mode to ``ConsoleMode/network``, the console will only display the
-    ///   network messages.
+    ///   - mode: The initial console mode. By default, ``ConsoleMode/all``. If you change
+    ///   the mode to ``ConsoleMode/network``, the console will display the
+    ///   network messages up on appearance.
     ///   - delegate: The delegate that allows you to customize multiple aspects
     ///   of the console view.
     public init(

--- a/Sources/PulseUI/Features/Console/List/ConsoleListContentView.swift
+++ b/Sources/PulseUI/Features/Console/List/ConsoleListContentView.swift
@@ -89,7 +89,9 @@ struct ConsoleListContentView: View {
 #if os(macOS)
     private func registerNowMode<T: View>(for list: T) -> some View {
         list.onChange(of: viewModel.entities) { entities in
-            guard isNowEnabled else { return }
+            /// From empty to 1 causes a bug on macOS where the first cell falls behind the overflow.
+            /// Check for count == 1 to always animate to the first inserted item.
+            guard isNowEnabled || entities.count == 1 else { return }
 
             withAnimation {
                 proxy.scrollTo(BottomViewID(), anchor: .top)

--- a/Sources/PulseUI/Features/Console/List/ConsoleListView.swift
+++ b/Sources/PulseUI/Features/Console/List/ConsoleListView.swift
@@ -174,8 +174,7 @@ private struct _ConsoleListView: View {
                     } else {
                         ConsoleListContentView(proxy: proxy)
                     }
-                }.scrollContentBackground(.hidden)
-                    .background(Color.black.opacity(0.32))
+                }
             }
             .environment(\.defaultMinListRowHeight, 1)
         }

--- a/Sources/PulseUI/Features/Console/List/ConsoleListView.swift
+++ b/Sources/PulseUI/Features/Console/List/ConsoleListView.swift
@@ -174,7 +174,8 @@ private struct _ConsoleListView: View {
                     } else {
                         ConsoleListContentView(proxy: proxy)
                     }
-                }
+                }.scrollContentBackground(.hidden)
+                    .background(Color.black.opacity(0.32))
             }
             .environment(\.defaultMinListRowHeight, 1)
         }

--- a/Sources/PulseUI/Features/Console/List/ConsoleListView.swift
+++ b/Sources/PulseUI/Features/Console/List/ConsoleListView.swift
@@ -174,7 +174,7 @@ private struct _ConsoleListView: View {
                     } else {
                         ConsoleListContentView(proxy: proxy)
                     }
-                }
+                }.scrollContentBackground(.hidden)
             }
             .environment(\.defaultMinListRowHeight, 1)
         }

--- a/Sources/PulseUI/Features/Sessions/SessionListView.swift
+++ b/Sources/PulseUI/Features/Sessions/SessionListView.swift
@@ -27,34 +27,40 @@ struct SessionListView: View {
     @Environment(\.store) private var store
 
     var body: some View {
-        if sessions.isEmpty {
-            Text("No Recorded Sessions")
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .foregroundColor(.secondary)
-        } else {
-            content
-                .onAppear { refreshGroups() }
-                .onChange(of: sessions.count) { _ in refreshGroups() }
+        VStack(spacing: 0) {
+            Text("Recorded sessions")
+                .padding(.vertical, 10)
+            Divider()
+            if sessions.isEmpty {
+                Text("No Recorded Sessions")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .foregroundColor(.secondary)
+            } else {
+                content
+                    .onAppear { refreshGroups() }
+                    .onChange(of: sessions.count) { _ in refreshGroups() }
+            }
         }
     }
 
     @ViewBuilder
     private var content: some View {
 #if os(macOS)
-        VStack {
+        VStack(spacing: 0) {
             list
-            HStack {
+            
 #if PULSE_STANDALONE_APP
+            HStack {
                 NavigatorFilterBar(text: $filterTerm)
                     .frame(maxWidth: 200)
                     .help("Show sessions with matching name")
+            }
 #else
-                SearchBar(title: "Filter", imageName: "line.3.horizontal.decrease.circle", text: $filterTerm)
-                    .frame(maxWidth: 200)
-                    .help("Show sessions with matching name")
+            Divider()
+            SearchBar(title: "Filter", imageName: "line.3.horizontal.decrease.circle", text: $filterTerm)
+                .help("Show sessions with matching name")
+                .padding(8)
 #endif
-                Spacer()
-            }.padding(8)
         }
 #else
         list
@@ -92,10 +98,14 @@ struct SessionListView: View {
 
     private func makeHeader(for startDate: Date, sessions: [LoggerSessionEntity]) -> some View {
         HStack {
+            #if os(macOS)
+            PlainListSectionHeaderSeparator(title: sectionTitleFormatter.string(from: startDate) + " (\(sessions.count))")
+            #else
             (Text(sectionTitleFormatter.string(from: startDate)) +
              Text(" (\(sessions.count))").foregroundColor(.secondary.opacity(0.5)))
             .font(.headline)
             .padding(.vertical, 6)
+            #endif
 
 #if os(iOS) || os(visionOS)
             if editMode?.wrappedValue.isEditing ?? false {

--- a/Sources/PulseUI/Features/Sessions/SessionListView.swift
+++ b/Sources/PulseUI/Features/Sessions/SessionListView.swift
@@ -28,9 +28,11 @@ struct SessionListView: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            #if os(macOS)
             Text("Recorded sessions")
                 .padding(.vertical, 10)
             Divider()
+            #endif
             if sessions.isEmpty {
                 Text("No Recorded Sessions")
                     .frame(maxWidth: .infinity, maxHeight: .infinity)


### PR DESCRIPTION
I've improved the session view based on UI consistency (e.g. section header) as well as affordance improvements. The view now contains a title "Recorded Sessions" and separates the list content from the footer and header. The Environment overrides popover in Xcode shows a similar UI structure.

| Before | After |
| --- | --- |
| ![CleanShot 2024-07-01 at 10 06 49@2x](https://github.com/kean/Pulse/assets/4329185/868c27bc-f2cf-4c57-9c00-d1bb9c732335) | ![CleanShot 2024-07-01 at 10 13 50@2x](https://github.com/kean/Pulse/assets/4329185/aed15ac9-9a86-409f-a8da-dbf8087834a7) |
