### PR TITLE
Improve macOS Settings View

### DIFF
--- a/Demo/macOS/Pulse_Demo_macOSApp.swift
+++ b/Demo/macOS/Pulse_Demo_macOSApp.swift
@@ -11,7 +11,6 @@ struct Pulse_Demo_macOSApp: App {
         WindowGroup {
             ConsoleView(store: .demo)
         }
-        .windowStyle(.hiddenTitleBar)
         .windowToolbarStyle(.unified(showsTitle: false))
     }
 }

--- a/Pulse.xcodeproj/project.pbxproj
+++ b/Pulse.xcodeproj/project.pbxproj
@@ -275,6 +275,7 @@
 		0CFF79E229EC1FA200BE767B /* ImageProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CFF79E029EC1F7800BE767B /* ImageProcessor.swift */; };
 		25E740012BE0FA58008C6DC3 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 25E740002BE0FA58008C6DC3 /* PrivacyInfo.xcprivacy */; };
 		25E740072BE10B4C008C6DC3 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 25E740062BE10B4C008C6DC3 /* PrivacyInfo.xcprivacy */; };
+		849DD7D92C32A9CE002D6787 /* ConsoleConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849DD7D82C32A9CE002D6787 /* ConsoleConfiguration.swift */; };
 		E95D6C562B7314E6004D28E4 /* HARDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = E95D6C552B7314E6004D28E4 /* HARDocument.swift */; };
 /* End PBXBuildFile section */
 
@@ -737,6 +738,7 @@
 		25E740062BE10B4C008C6DC3 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		49E82A8526D107A00070244F /* AlamofireIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlamofireIntegration.swift; sourceTree = "<group>"; };
 		49E82A8826D1083D0070244F /* MoyaIntegration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoyaIntegration.swift; sourceTree = "<group>"; };
+		849DD7D82C32A9CE002D6787 /* ConsoleConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsoleConfiguration.swift; sourceTree = "<group>"; };
 		E95D6C552B7314E6004D28E4 /* HARDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HARDocument.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -1398,6 +1400,7 @@
 				0CA2632D2BFA3855003C8E97 /* ConsoleDelegate.swift */,
 				0CF0D60A296F189600EED9D4 /* ConsoleEnvironment.swift */,
 				0CECF63C2996BE12000F9CCD /* ConsoleDataSource.swift */,
+				849DD7D82C32A9CE002D6787 /* ConsoleConfiguration.swift */,
 			);
 			path = Console;
 			sourceTree = "<group>";
@@ -2136,6 +2139,7 @@
 				0CDC3BED2971B936003BD1FF /* ConsoleSearchLogLevelsCell.swift in Sources */,
 				0CF0D620296F189600EED9D4 /* Foundation+Extensions.swift in Sources */,
 				0CF0D66C296F189600EED9D4 /* NetworkRequestInfoCell.swift in Sources */,
+				849DD7D92C32A9CE002D6787 /* ConsoleConfiguration.swift in Sources */,
 				0CB63A15297438A600525165 /* ConsoleSearchViewModel.swift in Sources */,
 				0CF0D632296F189600EED9D4 /* ShareStoreView.swift in Sources */,
 				0C9751582A32CCC400DC46FF /* RemoteLoggerEnterPasswordView.swift in Sources */,

--- a/Sources/Pulse/LoggerStore/LoggerStore.swift
+++ b/Sources/Pulse/LoggerStore/LoggerStore.swift
@@ -347,7 +347,7 @@ extension LoggerStore {
     }
 
     /// Handles event created by the current store and dispatches it to observers.
-    func handle(_ event: Event) {
+    public func handle(_ event: Event) {
         guard let event = configuration.willHandleEvent(event) else {
             return
         }

--- a/Sources/Pulse/RemoteLogger/RemoteLogger-Connection.swift
+++ b/Sources/Pulse/RemoteLogger/RemoteLogger-Connection.swift
@@ -11,13 +11,13 @@ import OSLog
 import Pulse
 #endif
 
-protocol RemoteLoggerConnectionDelegate: AnyObject {
+public protocol RemoteLoggerConnectionDelegate: AnyObject {
     func connection(_ connection: RemoteLogger.Connection, didChangeState newState: NWConnection.State)
     func connection(_ connection: RemoteLogger.Connection, didReceiveEvent event: RemoteLogger.Connection.Event)
 }
 
-extension RemoteLogger {
-    final class Connection {
+public extension RemoteLogger {
+    public final class Connection {
         var endpoint: NWEndpoint { connection.endpoint }
         private let connection: NWConnection
         private var buffer = Data()
@@ -31,14 +31,15 @@ extension RemoteLogger {
             self.init(NWConnection(to: endpoint, using: parameters))
         }
 
-        init(_ connection: NWConnection) {
+        public init(_ connection: NWConnection, delegate: RemoteLoggerConnectionDelegate? = nil) {
             self.connection = connection
+            self.delegate = delegate
 
             let isLogEnabled = UserDefaults.standard.bool(forKey: "com.github.kean.pulse.debug")
             self.log = isLogEnabled ? OSLog(subsystem: "com.github.kean.pulse", category: "RemoteLogger") : .disabled
         }
-
-        func start(on queue: DispatchQueue) {
+        
+        public func start(on queue: DispatchQueue) {
             connection.stateUpdateHandler = { [weak self] state in
                 guard let self = self else { return }
                 DispatchQueue.main.async {
@@ -49,15 +50,15 @@ extension RemoteLogger {
             connection.start(queue: queue)
         }
 
-        enum Event {
+        public enum Event {
             case packet(Packet)
             case error(Error)
             case completed
         }
 
-        struct Packet {
-            let code: UInt8
-            let body: Data
+        public struct Packet {
+            public let code: UInt8
+            public let body: Data
         }
 
         private func receive() {
@@ -130,7 +131,7 @@ extension RemoteLogger {
             }
         }
         
-        func send(code: UInt8, data: Data) {
+        public func send(code: UInt8, data: Data) {
             do {
                 let data = try encode(code: code, body: data)
                 let log = self.log
@@ -144,7 +145,7 @@ extension RemoteLogger {
             }
         }
 
-        func send<T: Encodable>(code: UInt8, entity: T) {
+        public func send<T: Encodable>(code: UInt8, entity: T) {
             do {
                 let data = try JSONEncoder().encode(entity)
                 send(code: code, data: data)
@@ -206,7 +207,7 @@ extension RemoteLogger {
             }
         }
         
-        func cancel() {
+        public func cancel() {
             connection.cancel()
         }
     }

--- a/Sources/Pulse/RemoteLogger/RemoteLogger-Protocol.swift
+++ b/Sources/Pulse/RemoteLogger/RemoteLogger-Protocol.swift
@@ -8,8 +8,8 @@ import Network
 import Pulse
 #endif
 
-extension RemoteLogger {
-    enum PacketCode: UInt8, Equatable {
+public extension RemoteLogger {
+    public enum PacketCode: UInt8, Equatable {
         // Handshake
         case clientHello = 0 // PacketClientHello
         case serverHello = 1 // ServerHelloResponse
@@ -44,7 +44,7 @@ extension RemoteLogger {
         init() {}
     }
     
-    struct PacketNetworkMessage {
+    public struct PacketNetworkMessage {
         private struct Manifest: Codable {
             let messageSize: UInt32
             let requestBodySize: UInt32
@@ -83,7 +83,7 @@ extension RemoteLogger {
             return data
         }
         
-        static func decode(_ data: Data) throws -> LoggerStore.Event.NetworkTaskCompleted {
+        public static func decode(_ data: Data) throws -> LoggerStore.Event.NetworkTaskCompleted {
             guard data.count >= Manifest.size else {
                 throw PacketParsingError.notEnoughData // Should never happen
             }
@@ -195,8 +195,12 @@ extension RemoteLogger {
         case openTaskDetails
     }
 
-    struct ServerHelloResponse: Codable {
+    public struct ServerHelloResponse: Codable {
         let version: String
+        
+        public init(version: String) {
+            self.version = version
+        }
     }
 }
 

--- a/Sources/Pulse/RemoteLogger/RemoteLogger.swift
+++ b/Sources/Pulse/RemoteLogger/RemoteLogger.swift
@@ -322,7 +322,7 @@ public final class RemoteLogger: ObservableObject, RemoteLoggerConnectionDelegat
 
         openConnection(to: server, passcode: passcode)
     }
-
+    
     private func connectionDidTimeout(isProtected: Bool) {
         os_log("Connection did timeout", log: log)
         connectionCompletion?(.failure(self.connectionError ?? .unknown(isProtected: isProtected)))
@@ -341,7 +341,7 @@ public final class RemoteLogger: ObservableObject, RemoteLoggerConnectionDelegat
     }
 
     private func saveServer(named name: String) {
-        os_log("Save server  %{private}@", log: log, name)
+        os_log("Save server %{private}@", log: log, name)
         knownServers.removeAll(where: { $0 == name })
         knownServers.append(name)
         saveKnownServers()
@@ -371,7 +371,7 @@ public final class RemoteLogger: ObservableObject, RemoteLoggerConnectionDelegat
 
     // MARK: RemoteLoggerConnectionDelegate
 
-    func connection(_ connection: Connection, didChangeState newState: NWConnection.State) {
+    public func connection(_ connection: Connection, didChangeState newState: NWConnection.State) {
         os_log("Connection did change state to %{public}@", log: log, "\(newState)")
 
         switch newState {
@@ -390,7 +390,7 @@ public final class RemoteLogger: ObservableObject, RemoteLoggerConnectionDelegat
         }
     }
 
-    func connection(_ connection: Connection, didReceiveEvent event: Connection.Event) {
+    public func connection(_ connection: Connection, didReceiveEvent event: Connection.Event) {
         switch event {
         case .packet(let packet):
             do {
@@ -730,5 +730,5 @@ extension RemoteLogger.ConnectionState {
 }
 
 extension RemoteLogger {
-    public static let serviceType = "_pulse._tcp"
+    public static var serviceType = "_pulse._tcp"
 }

--- a/Sources/PulseUI/Features/Console/ConsoleConfiguration.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleConfiguration.swift
@@ -11,10 +11,16 @@ public struct ConsoleConfiguration {
     public static let `default` = ConsoleConfiguration()
     
     let shareStoreOutputs: [ShareStoreOutput]
+    let allowRemoteLogging: Bool
     
     /// Creates a new `ConsoleConfiguration`
     /// - Parameter shareStoreOutputs: The available store share outputs. Defaults to `allCases`.
-    public init(shareStoreOutputs: [ShareStoreOutput] = ShareStoreOutput.allCases) {
+    /// - Parameter allowRemoteLogging: Enable/disable the remote logging option.
+    public init(
+        shareStoreOutputs: [ShareStoreOutput] = ShareStoreOutput.allCases,
+        allowRemoteLogging: Bool = true
+    ) {
         self.shareStoreOutputs = shareStoreOutputs
+        self.allowRemoteLogging = allowRemoteLogging
     }
 }

--- a/Sources/PulseUI/Features/Console/ConsoleConfiguration.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleConfiguration.swift
@@ -1,0 +1,20 @@
+// The MIT License (MIT)
+//
+//  Created by A.J. van der Lee on 01/07/2024.
+//  Copyright © 2024 kean. All rights reserved.
+//
+
+import Foundation
+
+/// Defines UI configurations to enable/disable elements or change behavior.
+public struct ConsoleConfiguration {
+    public static let `default` = ConsoleConfiguration()
+    
+    let shareStoreOutputs: [ShareStoreOutput]
+    
+    /// Creates a new `ConsoleConfiguration`
+    /// - Parameter shareStoreOutputs: The available store share outputs. Defaults to `allCases`.
+    public init(shareStoreOutputs: [ShareStoreOutput] = ShareStoreOutput.allCases) {
+        self.shareStoreOutputs = shareStoreOutputs
+    }
+}

--- a/Sources/PulseUI/Features/Console/ConsoleEnvironment.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleEnvironment.swift
@@ -24,6 +24,7 @@ final class ConsoleEnvironment: ObservableObject {
 
     let initialMode: ConsoleMode
     let delegate: ConsoleViewDelegate
+    let configuration: ConsoleConfiguration
 
     @Published var mode: ConsoleMode
     @Published var listOptions: ConsoleListOptions = .init()
@@ -38,7 +39,7 @@ final class ConsoleEnvironment: ObservableObject {
 
     private var cancellables: [AnyCancellable] = []
 
-    init(store: LoggerStore, mode: ConsoleMode = .all, delegate: ConsoleViewDelegate = DefaultConsoleViewDelegate()) {
+    init(store: LoggerStore, mode: ConsoleMode = .all, configuration: ConsoleConfiguration = .default, delegate: ConsoleViewDelegate = DefaultConsoleViewDelegate()) {
         self.store = store
         switch mode {
         case .all: self.title = "Console"
@@ -54,6 +55,7 @@ final class ConsoleEnvironment: ObservableObject {
         }
 
         self.delegate = delegate
+        self.configuration = configuration
 
         func makeDefaultOptions() -> ConsoleDataSource.PredicateOptions {
             var options = ConsoleDataSource.PredicateOptions()

--- a/Sources/PulseUI/Features/Console/ConsoleView-macos.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleView-macos.swift
@@ -51,7 +51,7 @@ private struct ConsoleMainView: View {
 
     private var contentView: some View {
         ConsoleListView()
-            .frame(minWidth: 200, idealWidth: 400, minHeight: 120, idealHeight: 480)
+            .frame(minWidth: 400, idealWidth: 500, minHeight: 120, idealHeight: 480)
             .toolbar {
                 ToolbarItemGroup(placement: .navigation) {
                     contentToolbarNavigationItems

--- a/Sources/PulseUI/Features/Console/ConsoleView-macos.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleView-macos.swift
@@ -60,18 +60,21 @@ private struct ConsoleMainView: View {
                     Button(action: { isShowingFilters = true }) {
                         Label("Show Filters", systemImage: "line.3.horizontal.decrease.circle")
                     }
+                    .help("Show Filters")
                     .popover(isPresented: $isShowingFilters) {
                         ConsoleFiltersView().frame(width: 300).fixedSize()
                     }
                     Button(action: { isShowingSessions = true }) {
                         Label("Show Sessions", systemImage: "list.clipboard")
                     }
+                    .help("Show Sessions")
                     .popover(isPresented: $isShowingSessions) {
                         SessionsView().frame(width: 300, height: 420)
                     }
                     Button(action: { isShowingSettings = true }) {
                         Label("Show Settings", systemImage: "gearshape")
                     }
+                    .help("Show Settings")
                     .popover(isPresented: $isShowingSettings) {
                         SettingsView().frame(width: 300, height: 420)
                     }
@@ -88,10 +91,11 @@ private struct ConsoleMainView: View {
         if !(environment.store.options.contains(.readonly)) {
             Toggle(isOn: $isNowEnabled) {
                 Image(systemName: "clock")
-            }
+            }.help("Now Mode: Automatically scrolls to the top of the view to display newly incoming network requests.")
             Button(action: { isSharingStore = true }) {
                 Image(systemName: "square.and.arrow.up")
             }
+            .help("Share a session")
             .popover(isPresented: $isSharingStore, arrowEdge: .bottom) {
                 ShareStoreView(onDismiss: {})
                     .frame(width: 240).fixedSize()
@@ -99,6 +103,7 @@ private struct ConsoleMainView: View {
             Button(action: { environment.store.removeAll() }) {
                 Image(systemName: "trash")
             }
+            .help("Clear current session")
         }
     }
 }

--- a/Sources/PulseUI/Features/Console/ConsoleView-macos.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleView-macos.swift
@@ -75,8 +75,8 @@ private struct ConsoleMainView: View {
                         Label("Show Settings", systemImage: "gearshape")
                     }
                     .help("Show Settings")
-                    .popover(isPresented: $isShowingSettings) {
-                        SettingsView().frame(width: 300, height: 420)
+                    .popover(isPresented: $isShowingSettings, arrowEdge: .bottom) {
+                        SettingsView().frame(width: 300, height: environment.configuration.allowRemoteLogging ? 420 : 175)
                     }
                 }
             }

--- a/Sources/PulseUI/Features/Console/ConsoleView.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleView.swift
@@ -9,19 +9,21 @@ import Combine
 
 extension ConsoleView {
     /// Initializes the console view.
-    ///
+    /// 
     /// - parameters:
     ///   - store: The store to display. By default, `LoggerStore/shared`.
     ///   - mode: The initial console mode. By default, ``ConsoleMode/all``. If you change
     ///   the mode to ``ConsoleMode/network``, the console will display the
     ///   network messages up on appearance.
+    ///   - configuration: Configuration options to alter the UI behavior and settings.
     ///   - delegate: The delegate that allows you to customize multiple aspects
     ///   of the console view.
     public init(
         store: LoggerStore = .shared,
         mode: ConsoleMode = .all,
+        configuration: ConsoleConfiguration = .default,
         delegate: ConsoleViewDelegate? = nil
     ) {
-        self.init(environment: .init(store: store, mode: mode, delegate: delegate ?? DefaultConsoleViewDelegate()))
+        self.init(environment: .init(store: store, mode: mode, configuration: configuration, delegate: delegate ?? DefaultConsoleViewDelegate()))
     }
 }

--- a/Sources/PulseUI/Features/Console/ConsoleView.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleView.swift
@@ -12,9 +12,9 @@ extension ConsoleView {
     ///
     /// - parameters:
     ///   - store: The store to display. By default, `LoggerStore/shared`.
-    ///   - mode: The console mode. By default, ``ConsoleMode/all``. If you change
-    ///   the mode to ``ConsoleMode/network``, the console will only display the
-    ///   network messages.
+    ///   - mode: The initial console mode. By default, ``ConsoleMode/all``. If you change
+    ///   the mode to ``ConsoleMode/network``, the console will display the
+    ///   network messages up on appearance.
     ///   - delegate: The delegate that allows you to customize multiple aspects
     ///   of the console view.
     public init(

--- a/Sources/PulseUI/Features/Console/List/ConsoleListContentView.swift
+++ b/Sources/PulseUI/Features/Console/List/ConsoleListContentView.swift
@@ -89,7 +89,9 @@ struct ConsoleListContentView: View {
 #if os(macOS)
     private func registerNowMode<T: View>(for list: T) -> some View {
         list.onChange(of: viewModel.entities) { entities in
-            guard isNowEnabled else { return }
+            /// From empty to 1 causes a bug on macOS where the first cell falls behind the overflow.
+            /// Check for count == 1 to always animate to the first inserted item.
+            guard isNowEnabled || entities.count == 1 else { return }
 
             withAnimation {
                 proxy.scrollTo(BottomViewID(), anchor: .top)

--- a/Sources/PulseUI/Features/Console/List/ConsoleListView.swift
+++ b/Sources/PulseUI/Features/Console/List/ConsoleListView.swift
@@ -174,8 +174,7 @@ private struct _ConsoleListView: View {
                     } else {
                         ConsoleListContentView(proxy: proxy)
                     }
-                }.scrollContentBackground(.hidden)
-                    .background(Color.black.opacity(0.32))
+                }
             }
             .environment(\.defaultMinListRowHeight, 1)
         }

--- a/Sources/PulseUI/Features/Console/List/ConsoleListView.swift
+++ b/Sources/PulseUI/Features/Console/List/ConsoleListView.swift
@@ -174,7 +174,8 @@ private struct _ConsoleListView: View {
                     } else {
                         ConsoleListContentView(proxy: proxy)
                     }
-                }
+                }.scrollContentBackground(.hidden)
+                    .background(Color.black.opacity(0.32))
             }
             .environment(\.defaultMinListRowHeight, 1)
         }

--- a/Sources/PulseUI/Features/Console/List/ConsoleListView.swift
+++ b/Sources/PulseUI/Features/Console/List/ConsoleListView.swift
@@ -174,7 +174,7 @@ private struct _ConsoleListView: View {
                     } else {
                         ConsoleListContentView(proxy: proxy)
                     }
-                }
+                }.scrollContentBackground(.hidden)
             }
             .environment(\.defaultMinListRowHeight, 1)
         }

--- a/Sources/PulseUI/Features/Sessions/SessionListView.swift
+++ b/Sources/PulseUI/Features/Sessions/SessionListView.swift
@@ -27,34 +27,40 @@ struct SessionListView: View {
     @Environment(\.store) private var store
 
     var body: some View {
-        if sessions.isEmpty {
-            Text("No Recorded Sessions")
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .foregroundColor(.secondary)
-        } else {
-            content
-                .onAppear { refreshGroups() }
-                .onChange(of: sessions.count) { _ in refreshGroups() }
+        VStack(spacing: 0) {
+            Text("Recorded sessions")
+                .padding(.vertical, 10)
+            Divider()
+            if sessions.isEmpty {
+                Text("No Recorded Sessions")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .foregroundColor(.secondary)
+            } else {
+                content
+                    .onAppear { refreshGroups() }
+                    .onChange(of: sessions.count) { _ in refreshGroups() }
+            }
         }
     }
 
     @ViewBuilder
     private var content: some View {
 #if os(macOS)
-        VStack {
+        VStack(spacing: 0) {
             list
-            HStack {
+            
 #if PULSE_STANDALONE_APP
+            HStack {
                 NavigatorFilterBar(text: $filterTerm)
                     .frame(maxWidth: 200)
                     .help("Show sessions with matching name")
+            }
 #else
-                SearchBar(title: "Filter", imageName: "line.3.horizontal.decrease.circle", text: $filterTerm)
-                    .frame(maxWidth: 200)
-                    .help("Show sessions with matching name")
+            Divider()
+            SearchBar(title: "Filter", imageName: "line.3.horizontal.decrease.circle", text: $filterTerm)
+                .help("Show sessions with matching name")
+                .padding(8)
 #endif
-                Spacer()
-            }.padding(8)
         }
 #else
         list
@@ -92,10 +98,14 @@ struct SessionListView: View {
 
     private func makeHeader(for startDate: Date, sessions: [LoggerSessionEntity]) -> some View {
         HStack {
+            #if os(macOS)
+            PlainListSectionHeaderSeparator(title: sectionTitleFormatter.string(from: startDate) + " (\(sessions.count))")
+            #else
             (Text(sectionTitleFormatter.string(from: startDate)) +
              Text(" (\(sessions.count))").foregroundColor(.secondary.opacity(0.5)))
             .font(.headline)
             .padding(.vertical, 6)
+            #endif
 
 #if os(iOS) || os(visionOS)
             if editMode?.wrappedValue.isEditing ?? false {

--- a/Sources/PulseUI/Features/Sessions/SessionListView.swift
+++ b/Sources/PulseUI/Features/Sessions/SessionListView.swift
@@ -28,9 +28,11 @@ struct SessionListView: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            #if os(macOS)
             Text("Recorded sessions")
                 .padding(.vertical, 10)
             Divider()
+            #endif
             if sessions.isEmpty {
                 Text("No Recorded Sessions")
                     .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/Sources/PulseUI/Features/Settings/SettingsView-macos.swift
+++ b/Sources/PulseUI/Features/Settings/SettingsView-macos.swift
@@ -12,14 +12,17 @@ struct SettingsView: View {
     @State private var shareItems: ShareItems?
 
     @Environment(\.store) private var store
+    @EnvironmentObject private var environment: ConsoleEnvironment
 
     var body: some View {
         List {
-            if store === RemoteLogger.shared.store {
-                RemoteLoggerSettingsView(viewModel: .shared)
-            } else {
-                Text("Not available")
-                    .foregroundColor(.secondary)
+            if environment.configuration.allowRemoteLogging {
+                if store === RemoteLogger.shared.store {
+                    RemoteLoggerSettingsView(viewModel: .shared)
+                } else {
+                    Text("Not available")
+                        .foregroundColor(.secondary)
+                }
             }
             Section(header: Text("Store")) {
                 if #available(macOS 13, *), let info = try? store.info() {

--- a/Sources/PulseUI/Features/Settings/SettingsView-macos.swift
+++ b/Sources/PulseUI/Features/Settings/SettingsView-macos.swift
@@ -7,6 +7,7 @@
 import SwiftUI
 import Pulse
 
+@available(macOS 13, *)
 struct SettingsView: View {
     @State private var isPresentingShareStoreView = false
     @State private var shareItems: ShareItems?
@@ -24,11 +25,14 @@ struct SettingsView: View {
                         .foregroundColor(.secondary)
                 }
             }
-            Section(header: Text("Store")) {
+            Section {
                 if #available(macOS 13, *), let info = try? store.info() {
                     LoggerStoreSizeChart(info: info, sizeLimit: store.configuration.sizeLimit)
                 }
+            } header: {
+                PlainListSectionHeaderSeparator(title: "Store")
             }
+            
             Section {
                 HStack {
                     Button("Show in Finder") {
@@ -41,13 +45,14 @@ struct SettingsView: View {
                     }
                 }
             }
-        }
+        }.listStyle(.sidebar).scrollContentBackground(.hidden)
     }
 }
 
 // MARK: - Preview
 
 #if DEBUG
+@available(macOS 13, *)
 struct UserSettingsView_Previews: PreviewProvider {
     static var previews: some View {
         SettingsView()

--- a/Sources/PulseUI/Helpers/ShareItems.swift
+++ b/Sources/PulseUI/Helpers/ShareItems.swift
@@ -6,7 +6,7 @@ import Foundation
 import Pulse
 import CoreData
 
-public enum ShareStoreOutput: String, RawRepresentable {
+public enum ShareStoreOutput: String, RawRepresentable, CaseIterable {
     case store, package, text, html, har
 
     var fileExtension: String {
@@ -15,6 +15,16 @@ public enum ShareStoreOutput: String, RawRepresentable {
         case .text: return "txt"
         case .html: return "html"
         case .har: return "har"
+        }
+    }
+    
+    var interfaceTitle: String {
+        switch self {
+        case .store: "Pulse"
+        case .package: "Pulse (Package)"
+        case .text: "Plain Text"
+        case .html: "HTML"
+        case .har: "HAR"
         }
     }
 }

--- a/Sources/PulseUI/Views/ShareStoreView.swift
+++ b/Sources/PulseUI/Views/ShareStoreView.swift
@@ -20,6 +20,7 @@ struct ShareStoreView: View {
     @StateObject private var viewModel = ShareStoreViewModel()
 
     @Environment(\.store) private var store: LoggerStore
+    @EnvironmentObject private var environment: ConsoleEnvironment
 
     var body: some View {
         content
@@ -30,6 +31,7 @@ struct ShareStoreView: View {
                     viewModel.sessions = [store.session.id]
                 }
                 viewModel.store = store
+                viewModel.environment = environment
             }
     }
 
@@ -95,12 +97,12 @@ struct ShareStoreView: View {
         }
         Section {
             Picker("Output", selection: $viewModel.output) {
-                Text("Pulse").tag(ShareStoreOutput.store)
-                Text("Plain Text").tag(ShareStoreOutput.text)
-                Text("HTML").tag(ShareStoreOutput.html)
-                Text("HAR").tag(ShareStoreOutput.har)
-                Divider()
-                Text("Pulse (Package)").tag(ShareStoreOutput.package)
+                ForEach(viewModel.shareStoreOutputs, id: \.rawValue) { shareOutput in
+                    if shareOutput == .package {
+                        Divider()
+                    }
+                    Text(shareOutput.interfaceTitle).tag(shareOutput)
+                }
             }
 #if os(macOS)
             .labelsHidden()


### PR DESCRIPTION
Improved the UI of the popover for settings. The UI is cleaner now mostly due to removing the background, which also fixes the background being different inside the arrow:

<img width="105" alt="CleanShot 2024-07-01 at 13 33 45@2x" src="https://github.com/kean/Pulse/assets/4329185/3d72a7ef-4c3d-419f-bd73-503e54715343">

| Before | After |
| --- | --- |
| ![CleanShot 2024-07-01 at 13 32 10@2x](https://github.com/kean/Pulse/assets/4329185/a3b1fd2b-29d1-408b-83d4-fbc8572c0935) | ![CleanShot 2024-07-01 at 13 31 11@2x](https://github.com/kean/Pulse/assets/4329185/cf6c946e-f231-4720-921b-8e4ea63cc7c3) |
