### PR TITLE
Provide public access to ConsoleDatasource

### DIFF
--- a/Sources/PulseUI/Extensions/Pulse+Extensions.swift
+++ b/Sources/PulseUI/Extensions/Pulse+Extensions.swift
@@ -7,13 +7,13 @@ import Pulse
 import SwiftUI
 import CoreData
 
-enum LoggerEntity {
+public enum LoggerEntity {
     /// Regular log, not task attached.
     case message(LoggerMessageEntity)
     /// Either a log with an attached task, or a task itself.
     case task(NetworkTaskEntity)
 
-    init(_ entity: NSManagedObject) {
+    public init(_ entity: NSManagedObject) {
         if let message = entity as? LoggerMessageEntity {
             if let task = message.task {
                 self = .task(task)
@@ -27,7 +27,7 @@ enum LoggerEntity {
         }
     }
 
-    var task: NetworkTaskEntity? {
+    public var task: NetworkTaskEntity? {
         if case .task(let task) = self { return task }
         return nil
     }
@@ -80,7 +80,7 @@ extension LoggerMessageEntity {
 }
 
 extension NetworkTaskEntity.State {
-    var tintColor: Color {
+    public var tintColor: Color {
         switch self {
         case .pending: return .orange
         case .success: return .green

--- a/Sources/PulseUI/Features/Console/ConsoleDataSource.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleDataSource.swift
@@ -8,7 +8,7 @@ import Pulse
 import Combine
 import SwiftUI
 
-protocol ConsoleDataSourceDelegate: AnyObject {
+public protocol ConsoleDataSourceDelegate: AnyObject {
     /// The data source reloaded the entire dataset.
     func dataSourceDidRefresh(_ dataSource: ConsoleDataSource)
 
@@ -17,22 +17,24 @@ protocol ConsoleDataSourceDelegate: AnyObject {
     func dataSource(_ dataSource: ConsoleDataSource, didUpdateWith diff: CollectionDifference<NSManagedObjectID>?)
 }
 
-final class ConsoleDataSource: NSObject, NSFetchedResultsControllerDelegate {
-    weak var delegate: ConsoleDataSourceDelegate?
+public final class ConsoleDataSource: NSObject, NSFetchedResultsControllerDelegate {
+    public weak var delegate: ConsoleDataSourceDelegate?
 
     /// - warning: Incompatible with the "group by" option.
     var sortDescriptors: [NSSortDescriptor] = [] {
         didSet { controller.fetchRequest.sortDescriptors = sortDescriptors }
     }
 
-    struct PredicateOptions {
-        var filters = ConsoleFilers()
-        var isOnlyErrors = false
-        var predicate: NSPredicate?
-        var focus: NSPredicate?
+    public struct PredicateOptions {
+        public var filters = ConsoleFilers()
+        public var isOnlyErrors = false
+        public var predicate: NSPredicate?
+        public var focus: NSPredicate?
+        
+        public init() { }
     }
 
-    var predicate: PredicateOptions = .init() {
+    public var predicate: PredicateOptions = .init() {
         didSet { refreshPredicate() }
     }
 
@@ -49,7 +51,7 @@ final class ConsoleDataSource: NSObject, NSFetchedResultsControllerDelegate {
     private var controllerDelegate: NSFetchedResultsControllerDelegate?
     private var cancellables: [AnyCancellable] = []
 
-    init(store: LoggerStore, mode: ConsoleMode, options: ConsoleListOptions = .init()) {
+    public init(store: LoggerStore, mode: ConsoleMode, options: ConsoleListOptions = .init()) {
         self.store = store
         self.mode = mode
         self.options = options
@@ -109,7 +111,7 @@ final class ConsoleDataSource: NSObject, NSFetchedResultsControllerDelegate {
         }.store(in: &cancellables)
     }
 
-    func refresh() {
+    public func refresh() {
         try? controller.performFetch()
         delegate?.dataSourceDidRefresh(self)
     }
@@ -124,21 +126,21 @@ final class ConsoleDataSource: NSObject, NSFetchedResultsControllerDelegate {
         controller.object(at: indexPath)
     }
     
-    var entities: [NSManagedObject] {
+    public var entities: [NSManagedObject] {
         controller.fetchedObjects ?? []
     }
     
-    var sections: [NSFetchedResultsSectionInfo]? {
+    public var sections: [NSFetchedResultsSectionInfo]? {
         controller.sectionNameKeyPath == nil ? nil : controller.sections
     }
     
     // MARK: NSFetchedResultsControllerDelegate
 
-    func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
+    public func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
         delegate?.dataSource(self, didUpdateWith: nil)
     }
 
-    func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChangeContentWith diff: CollectionDifference<NSManagedObjectID>) {
+    public func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChangeContentWith diff: CollectionDifference<NSManagedObjectID>) {
         delegate?.dataSource(self, didUpdateWith: diff)
     }
 

--- a/Sources/PulseUI/Features/Console/List/ConsoleListOptions.swift
+++ b/Sources/PulseUI/Features/Console/List/ConsoleListOptions.swift
@@ -5,24 +5,41 @@
 import Foundation
 import Pulse
 
-struct ConsoleListOptions: Equatable {
-    var messageSortBy: MessageSortBy = .dateCreated
-    var taskSortBy: TaskSortBy = .dateCreated
-#if os(macOS)
-    var order: Ordering = .ascending
-#else
-    var order: Ordering = .descending
-#endif
-
+public struct ConsoleListOptions: Equatable {
+    var messageSortBy: MessageSortBy
+    var taskSortBy: TaskSortBy
+    var order: Ordering
     var messageGroupBy: MessageGroupBy = .noGrouping
     var taskGroupBy: TaskGroupBy = .noGrouping
 
-    enum Ordering: String, CaseIterable {
+    public init(
+        messageSortBy: MessageSortBy = .dateCreated,
+        taskSortBy: TaskSortBy = .dateCreated,
+        order: Ordering = .default,
+        messageGroupBy: MessageGroupBy = .noGrouping,
+        taskGroupBy: TaskGroupBy = .noGrouping
+    ) {
+        self.messageSortBy = messageSortBy
+        self.taskSortBy = taskSortBy
+        self.order = order
+        self.messageGroupBy = messageGroupBy
+        self.taskGroupBy = taskGroupBy
+    }
+    
+    public enum Ordering: String, CaseIterable {
         case descending = "Descending"
         case ascending = "Ascending"
+        
+        public static var `default`: Ordering {
+        #if os(macOS)
+            .ascending
+        #else
+            .descending
+        #endif
+        }
     }
 
-    enum MessageSortBy: String, CaseIterable {
+    public enum MessageSortBy: String, CaseIterable {
         case dateCreated = "Date"
         case level = "Level"
 
@@ -34,7 +51,7 @@ struct ConsoleListOptions: Equatable {
         }
     }
 
-    enum TaskSortBy: String, CaseIterable {
+    public enum TaskSortBy: String, CaseIterable {
         case dateCreated = "Date"
         case duration = "Duration"
         case requestSize = "Request Size"
@@ -50,7 +67,7 @@ struct ConsoleListOptions: Equatable {
         }
     }
 
-    enum MessageGroupBy: String, CaseIterable, ConsoleListGroupBy {
+    public enum MessageGroupBy: String, CaseIterable, ConsoleListGroupBy {
         case noGrouping = "No Grouping"
         case label = "Label"
         case level = "Level"
@@ -75,7 +92,7 @@ struct ConsoleListOptions: Equatable {
         }
     }
 
-    enum TaskGroupBy: ConsoleListGroupBy {
+    public enum TaskGroupBy: ConsoleListGroupBy {
         case noGrouping
         case url
         case host

--- a/Sources/PulseUI/Features/Filters/Filters/ConsoleFilers.swift
+++ b/Sources/PulseUI/Features/Filters/Filters/ConsoleFilers.swift
@@ -8,27 +8,27 @@ import CoreData
 import Combine
 
 /// Filter the logs displayed in the console.
-struct ConsoleFilers: Hashable {
-    var shared = Shared()
-    var messages = Messages()
-    var network = Network()
+public struct ConsoleFilers: Hashable {
+    public var shared = Shared()
+    public var messages = Messages()
+    public var network = Network()
 
-    struct Shared: Hashable {
-        var sessions = Sessions()
-        var dates = Dates()
+    public struct Shared: Hashable {
+        public var sessions = Sessions()
+        public var dates = Dates()
     }
 
-    struct Messages: Hashable {
-        var logLevels = LogLevels()
-        var labels = Labels()
+    public struct Messages: Hashable {
+        public var logLevels = LogLevels()
+        public var labels = Labels()
 #if PULSE_STANDALONE_APP
         var custom = CustomMessageFilters()
 #endif
     }
 
-    struct Network: Hashable {
-        var host = Host()
-        var url = URL()
+    public struct Network: Hashable {
+        public var host = Host()
+        public var url = URL()
 #if PULSE_STANDALONE_APP
         var custom = CustomNetworkFilters()
         var response = Response()
@@ -42,47 +42,47 @@ protocol ConsoleFilterProtocol: Hashable {
     init() // Initializes with the default values
 }
 
-extension ConsoleFilers {
+public extension ConsoleFilers {
     struct Sessions: Hashable, ConsoleFilterProtocol {
-        var isEnabled = true
-        var selection: Set<UUID> = []
+        public var isEnabled = true
+        public var selection: Set<UUID> = []
     }
 
     struct Dates: Hashable, ConsoleFilterProtocol {
-        var isEnabled = true
-        var startDate: Date?
-        var endDate: Date?
+        public var isEnabled = true
+        public var startDate: Date?
+        public var endDate: Date?
 
-        static var today: Dates {
+        public static var today: Dates {
             Dates(startDate: Calendar.current.startOfDay(for: Date()))
         }
 
-        static var recent: Dates {
+        public static var recent: Dates {
             Dates(startDate: Date().addingTimeInterval(-1200))
         }
     }
 
     struct LogLevels: ConsoleFilterProtocol {
-        var isEnabled = true
-        var levels: Set<LoggerStore.Level> = Set(LoggerStore.Level.allCases)
+        public var isEnabled = true
+        public var levels: Set<LoggerStore.Level> = Set(LoggerStore.Level.allCases)
             .subtracting([LoggerStore.Level.trace])
     }
 
     struct Labels: ConsoleFilterProtocol {
-        var isEnabled = true
-        var hidden: Set<String> = []
-        var focused: String?
+        public var isEnabled = true
+        public var hidden: Set<String> = []
+        public var focused: String?
     }
 
     struct Host: ConsoleFilterProtocol {
-        var isEnabled = true
-        var hidden: Set<String> = []
-        var focused: String?
+        public var isEnabled = true
+        public var hidden: Set<String> = []
+        public var focused: String?
     }
 
     struct URL: ConsoleFilterProtocol {
-        var isEnabled = true
-        var hidden: Set<String> = []
-        var focused: String?
+        public var isEnabled = true
+        public var hidden: Set<String> = []
+        public var focused: String?
     }
 }

--- a/Sources/PulseUI/Helpers/StatusLabelViewModel.swift
+++ b/Sources/PulseUI/Helpers/StatusLabelViewModel.swift
@@ -6,12 +6,12 @@ import Foundation
 import SwiftUI
 import Pulse
 
-struct StatusLabelViewModel {
+public struct StatusLabelViewModel {
     let systemImage: String
     let tint: Color
     let title: String
 
-    init(task: NetworkTaskEntity, store: LoggerStore) {
+    public init(task: NetworkTaskEntity, store: LoggerStore) {
         guard let state = task.state(in: store) else {
             self.systemImage = "questionmark.diamond.fill"
             self.tint = .secondary
@@ -52,7 +52,7 @@ struct StatusLabelViewModel {
         }
     }
 
-    var text: Text {
+    public var text: Text {
         (Text(Image(systemName: systemImage)) + Text(" " + title))
             .foregroundColor(tint)
     }


### PR DESCRIPTION
This opens up some of the APIs to allow fetching entities outside of PulseUI. This is great of building custom UIs or a custom Console.