### PR TITLE
Fix PDF export in dark mode (#231)

### DIFF
--- a/Sources/PulseUI/Helpers/TextUtilities.swift
+++ b/Sources/PulseUI/Helpers/TextUtilities.swift
@@ -111,6 +111,13 @@ enum TextUtilities {
         let bounds = UIGraphicsGetPDFContextBounds()
         for i in 0  ..< renderer.numberOfPages {
             UIGraphicsBeginPDFPage()
+            
+            if isDarkMode, let context = UIGraphicsGetCurrentContext() {
+                let backgroundColor = UIColor(red: 44/255.0, green: 42/255.0, blue: 40/255.0, alpha: 1.0)
+                context.setFillColor(backgroundColor.cgColor)
+                context.fill(bounds)
+            }
+            
             renderer.drawPage(at: i, in: bounds)
         }
         UIGraphicsEndPDFContext()


### PR DESCRIPTION
### Description of change

Summary: Fixed PDF export in dark mode (added the same background color as for HTML).

### Issues resolved

- Fixes #231 

### Files

<details>
 <summary>Open files</summary>

[logs-2024-09-04-11-46-dark-mode.pdf](https://github.com/user-attachments/files/16863383/logs-2024-09-04-11-46-dark-mode.pdf)

[logs-2024-09-04-11-46-light-mode.pdf](https://github.com/user-attachments/files/16863384/logs-2024-09-04-11-46-light-mode.pdf)

</details>
