### PR TITLE
Fix Xcode 16 Beta warnings related to unhandled files

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,19 +8,19 @@ let package = Package(
         .tvOS(.v15),
         .macOS(.v12),
         .watchOS(.v8),
-        .visionOS(.v1)
+        .visionOS(.v1),
     ],
     products: [
         .library(name: "Pulse", targets: ["Pulse"]),
         .library(name: "PulseProxy", targets: ["PulseProxy"]),
-        .library(name: "PulseUI", targets: ["PulseUI"])
+        .library(name: "PulseUI", targets: ["PulseUI"]),
     ],
     targets: [
-        .target(name: "Pulse"),
+        .target(name: "Pulse", exclude: ["PrivacyInfo.xcprivacy"]),
         .target(name: "PulseProxy", dependencies: ["Pulse"]),
-        .target(name: "PulseUI", dependencies: ["Pulse"]),
+        .target(name: "PulseUI", dependencies: ["Pulse"], exclude: ["PrivacyInfo.xcprivacy"]),
     ],
     swiftLanguageVersions: [
-      .v5
+        .v5
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -16,9 +16,11 @@ let package = Package(
         .library(name: "PulseUI", targets: ["PulseUI"]),
     ],
     targets: [
-        .target(name: "Pulse", exclude: ["PrivacyInfo.xcprivacy"]),
+        .target(name: "Pulse", resources: [.process("PrivacyInfo.xcprivacy")]),
         .target(name: "PulseProxy", dependencies: ["Pulse"]),
-        .target(name: "PulseUI", dependencies: ["Pulse"], exclude: ["PrivacyInfo.xcprivacy"]),
+        .target(
+            name: "PulseUI", dependencies: ["Pulse"], resources: [.process("PrivacyInfo.xcprivacy")]
+        ),
     ],
     swiftLanguageVersions: [
         .v5


### PR DESCRIPTION
Exclude "PrivacyInfo.xcprivacy" files from "Pulse" and "PulseUI" targets in Package.swift.

Fix these warnings
<img width="1125" alt="Screenshot 2024-09-09 at 10 30 22" src="https://github.com/user-attachments/assets/52c449cd-991b-4b0a-8ecb-622a08422450">
