### PR TITLE
`ConsoleView` focus state clipping on tvOS

### DIFF
--- a/Sources/PulseUI/Features/Console/ConsoleView-tvos.swift
+++ b/Sources/PulseUI/Features/Console/ConsoleView-tvos.swift
@@ -37,6 +37,7 @@ public struct ConsoleView: View {
             .onAppear { listViewModel.isViewVisible = true }
             .onDisappear { listViewModel.isViewVisible = false }
         }
+        .disableScrollClip()
         .injecting(environment)
         .environmentObject(listViewModel)
     }
@@ -89,6 +90,17 @@ private struct ConsoleMenuView: View {
 
     private var destinationFilters: some View {
         ConsoleFiltersView().padding()
+    }
+}
+
+extension View {
+    @available(tvOS, obsoleted: 17.0, renamed: "scrollClipDisabled")
+    @ViewBuilder func disableScrollClip() -> some View {
+        if #available(tvOS 17.0, *) {
+            scrollClipDisabled()
+        } else {
+            self
+        }
     }
 }
 

--- a/Sources/PulseUI/Features/Inspector/NetworkInspectorView-tvos.swift
+++ b/Sources/PulseUI/Features/Inspector/NetworkInspectorView-tvos.swift
@@ -26,6 +26,7 @@ struct NetworkInspectorView: View {
             Form { lhs }.frame(width: 740)
             Form { rhs }
         }
+        .disableScrollClip()
     }
 
     @ViewBuilder


### PR DESCRIPTION
Disables the console UI’s scroll clipping on tvOS. This ensures that the cells' focused states are not clipped.
| Before | After |
| --- | --- |
| ![Before](https://github.com/user-attachments/assets/66170914-8199-4e4b-9285-f9c22506a71e) | ![After](https://github.com/user-attachments/assets/7edfd59f-fdc9-4d67-8566-ae25b0012d29) |