### PR TITLE
Fix crash when exporting HAR file

### DIFF
--- a/Sources/Pulse/LoggerStore/LoggerStore.swift
+++ b/Sources/Pulse/LoggerStore/LoggerStore.swift
@@ -766,9 +766,10 @@ extension LoggerStore {
     /// - parameter predicate: By default, `nil`.
     public func messages(
         sortDescriptors: [SortDescriptor<LoggerMessageEntity>] = [SortDescriptor(\.createdAt, order: .forward)],
-        predicate: NSPredicate? = nil
+        predicate: NSPredicate? = nil,
+        context: NSManagedObjectContext? = nil
     ) throws -> [LoggerMessageEntity] {
-        try viewContext.fetch(LoggerMessageEntity.self) {
+        try (context ?? viewContext).fetch(LoggerMessageEntity.self) {
             $0.sortDescriptors = sortDescriptors.map(NSSortDescriptor.init)
             $0.predicate = predicate
         }
@@ -781,9 +782,10 @@ extension LoggerStore {
     /// - parameter predicate: By default, `nil`.
     public func tasks(
         sortDescriptors: [SortDescriptor<NetworkTaskEntity>] = [SortDescriptor(\.createdAt, order: .forward)],
-        predicate: NSPredicate? = nil
+        predicate: NSPredicate? = nil,
+        context: NSManagedObjectContext? = nil
     ) throws -> [NetworkTaskEntity] {
-        try viewContext.fetch(NetworkTaskEntity.self) {
+        try (context ?? viewContext).fetch(NetworkTaskEntity.self) {
             $0.sortDescriptors = sortDescriptors.map(NSSortDescriptor.init)
             $0.predicate = predicate
         }

--- a/Sources/PulseUI/Helpers/HARDocument.swift
+++ b/Sources/PulseUI/Helpers/HARDocument.swift
@@ -18,7 +18,7 @@ struct HARDocument: Encodable {
     init(store: LoggerStore) throws {
         var entries: [Entry] = []
         var pages: [Page] = []
-        try Dictionary(grouping: store.tasks(), by: \.url).values.forEach { networkTasks in
+        try Dictionary(grouping: store.tasks(context: store.backgroundContext), by: \.url).values.forEach { networkTasks in
             let pageId = "page_\(pages.count)"
             pages.append(
                 .init(
@@ -29,7 +29,7 @@ struct HARDocument: Encodable {
             )
             entries.append(contentsOf: networkTasks.map { .init(entity: $0, pageId: pageId) })
         }
-        try store.messages().forEach { message in
+        try store.messages(context: store.backgroundContext).forEach { message in
             if let task = message.task {
                 entries.append(.init(entity: task, pageId: "page_\(pages.count)"))
             }


### PR DESCRIPTION
The crash was happening because we were accessing main context from a background thread.

Fixed it by passing backgroundContext when fetching entities from Core Data.

Screenshot of the crash:
<img width="1624" alt="Screenshot 2024-10-04 at 10 47 19 AM" src="https://github.com/user-attachments/assets/997d30a1-6ba4-45d8-8f84-5bb7c75d4ea8">

HAR export after the fix succeeding:
https://github.com/user-attachments/assets/07e6025d-895a-4706-980c-651c80d0fb7f

