### PR TITLE
Fix concurrency issue in `StoreDetailsViewModel`

### DIFF
--- a/Sources/PulseUI/Features/Settings/StoreDetailsView.swift
+++ b/Sources/PulseUI/Features/Settings/StoreDetailsView.swift
@@ -13,7 +13,7 @@ struct StoreDetailsView: View {
 
     var body: some View {
         StoreDetailsContentsView(viewModel: viewModel)
-            .onAppear { viewModel.load(from: source) }
+            .task { await viewModel.load(from: source) }
 #if os(tvOS)
             .padding()
 #else
@@ -97,18 +97,16 @@ enum StoreDetailsViewSource {
 
 // MARK: - ViewModel
 
-final class StoreDetailsViewModel: ObservableObject {
+@MainActor final class StoreDetailsViewModel: ObservableObject {
     @Published private(set) var storeSizeLimit: Int64?
     @Published private(set) var sections: [KeyValueSectionViewModel] = []
     @Published private(set) var info: LoggerStore.Info?
     @Published private(set) var errorMessage: String?
 
-    func load(from source: StoreDetailsViewSource) {
+    func load(from source: StoreDetailsViewSource) async {
         switch source {
         case .store(let store):
-            Task {
-                await loadInfo(for: store)
-            }
+            await loadInfo(for: store)
         case .info(let value):
             display(value)
         }


### PR DESCRIPTION
This PR prevents runtime warnings when viewing the `StoreDetailsView`. The warning is produced when mutating `@Published` `StoreDetailsViewModel` properties on a background queue. This PR fixes the issue by isolating `StoreDetailsViewModel` to the `MainActor`.

<img width="617" alt="Runtime Warnings" src="https://github.com/user-attachments/assets/9132e59d-80d4-47f7-b19e-af0fad192707">