### PR TITLE
Fix deadlock in NetworkLogger

### DIFF
--- a/Sources/Pulse/NetworkLogger/NetworkLogger.swift
+++ b/Sources/Pulse/NetworkLogger/NetworkLogger.swift
@@ -161,6 +161,7 @@ public final class NetworkLogger: @unchecked Sendable {
     public func logTaskCreated(_ task: URLSessionTask) {
         lock.lock()
         guard tasks[TaskKey(task: task)] == nil else {
+            lock.unlock()
             return // Already registered
         }
         let context = context(for: task)


### PR DESCRIPTION
👋 This PR fixes a deadlock that could occur if `logTaskCreated` was called with a task that already existed.

IMO it would be best to update this code to use safer primitives like `withLock` (and ultimately drop the `@unchecked Sendable` by using Concurrency-friendly APIs like [os.OSAllocatedUnfairLock](https://developer.apple.com/documentation/os/osallocatedunfairlock), [Synchronization.Mutex](https://developer.apple.com/documentation/synchronization/mutex), or [ConcurrencyExtras.LockIsolated](https://github.com/pointfreeco/swift-concurrency-extras/blob/82a4ae7170d98d8538ec77238b7eb8e7199ef2e8/Sources/ConcurrencyExtras/LockIsolated.swift)) — but that's a larger change so I haven't endeavored to do that atm.