### PR TITLE
Adds a public API for sweep

### DIFF
--- a/Sources/Pulse/LoggerStore/LoggerStore.swift
+++ b/Sources/Pulse/LoggerStore/LoggerStore.swift
@@ -210,11 +210,7 @@ public final class LoggerStore: @unchecked Sendable, Identifiable {
 
         if !isArchive && !options.contains(.readonly) {
             try save(manifest)
-            if isAutomaticSweepNeeded {
-                DispatchQueue.global().asyncAfter(deadline: .now() + .seconds(10)) { [weak self] in
-                    self?.sweep()
-                }
-            }
+            sweepIfNeeded()
         }
     }
 
@@ -1079,6 +1075,13 @@ extension LoggerStore {
 // MARK: - LoggerStore (Sweep)
 
 extension LoggerStore {
+    public func sweepIfNeeded() {
+        guard isAutomaticSweepNeeded else { return }
+        DispatchQueue.global().asyncAfter(deadline: .now() + .seconds(10)) { [weak self] in
+            self?.sweep()
+        }
+    }
+
     var isAutomaticSweepNeeded: Bool {
         guard options.contains(.sweep) && !isArchive else { return false }
         guard let lastSweepDate = manifest.lastSweepDate else {


### PR DESCRIPTION
Currently, LoggerStore only chooses to sweep once on init. We want to provide an opportunity for it to sweep more often by calling into this on application lifecycle events like backgrounding