### PR TITLE
LoggerStore + NetworkLogger + Redacted + Patterns

### DIFF
--- a/Sources/Pulse/LoggerStore/LoggerStore+Configuration.swift
+++ b/Sources/Pulse/LoggerStore/LoggerStore+Configuration.swift
@@ -90,6 +90,8 @@ extension LoggerStore {
         /// ``LoggerStore/Options-swift.struct/sweep`` option. The default store supports sweeps.
         public var maxAge: TimeInterval = 14 * 86400
 
+        public var redacted: Redacted = Redacted()
+
         /// Gets called when the store receives an event. You can use it to
         /// modify the event before it is stored in order, for example, filter
         /// out some sensitive information. If you return `nil`, the event

--- a/Sources/Pulse/Redacted/Redacted.swift
+++ b/Sources/Pulse/Redacted/Redacted.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+public struct Redacted: Sendable {
+    /// Store logs only for the included hosts.
+    ///
+    /// - note: Supports wildcards, e.g. `*.example.com`, and full regex
+    /// when ``isRegexEnabled`` option is enabled.
+    public var includedHosts: Set<String> = []
+
+    /// Store logs only for the included URLs.
+    ///
+    /// - note: Supports wildcards, e.g. `*.example.com`, and full regex
+    /// when ``isRegexEnabled`` option is enabled.
+    public var includedURLs: Set<String> = []
+
+    /// Exclude the given hosts from the logs.
+    ///
+    /// - note: Supports wildcards, e.g. `*.example.com`, and full regex
+    /// when ``isRegexEnabled`` option is enabled.
+    public var excludedHosts: Set<String> = []
+
+    /// Exclude the given URLs from the logs.
+    ///
+    /// - note: Supports wildcards, e.g. `*.example.com`, and full regex
+    /// when ``isRegexEnabled`` option is enabled.
+    public var excludedURLs: Set<String> = []
+
+    /// Redact the given HTTP headers from the logged requests and responses.
+    ///
+    /// - note: Supports wildcards, e.g. `X-*`, and full regex
+    /// when ``isRegexEnabled`` option is enabled.
+    public var sensitiveHeaders: Set<String> = []
+
+    /// Redact the given query items from the URLs.
+    ///
+    /// - note: Supports only plain strings. Case-sensitive.
+    public var sensitiveQueryItems: Set<String> = []
+
+    /// Redact the given JSON fields from the logged requests and responses bodies.
+    ///
+    /// - note: Supports only plain strings. Case-sensitive.
+    public var sensitiveDataFields: Set<String> = []
+
+    /// If enabled, processes `include` and `exclude` patterns using regex.
+    /// By default, patterns support only basic wildcard syntax: `*.example.com`.
+    public var isRegexEnabled = false
+
+    public init() {}
+
+    func patterns() -> Patterns {
+        func process(_ pattern: String) -> Regex? {
+            process(pattern, options: [])
+        }
+
+        func process(_ pattern: String, options: [Regex.Options]) -> Regex? {
+            do {
+                let pattern = isRegexEnabled ? pattern : expandingWildcards(pattern)
+                return try Regex(pattern)
+            } catch {
+                debugPrint("Failed to parse pattern: \(pattern) \(error)")
+                return nil
+            }
+        }
+
+        func expandingWildcards(_ pattern: String) -> String {
+            let pattern = NSRegularExpression.escapedPattern(for: pattern)
+                .replacingOccurrences(of: "\\?", with: ".")
+                .replacingOccurrences(of: "\\*", with: "[^\\s]*")
+            return "^\(pattern)$"
+        }
+
+        return Patterns(
+            includedHosts: includedHosts.compactMap(process),
+            includedURLs: includedURLs.compactMap(process),
+            excludedHosts: excludedHosts.compactMap(process),
+            excludedURLs: excludedURLs.compactMap(process),
+            sensitiveHeaders: sensitiveHeaders.compactMap {
+                process($0, options: [.caseInsensitive])
+            },
+            sensitiveQueryItems: sensitiveQueryItems,
+            sensitiveDataFields: sensitiveDataFields,
+            isFilteringNeeded: !includedHosts.isEmpty || !excludedHosts.isEmpty || !includedURLs.isEmpty || !excludedURLs.isEmpty
+        )
+    }
+}


### PR DESCRIPTION
I've extracted fields that are responsible for redacting into its own struct `Redacted` from `NetworkLogger.Configuration`. I then created an internal type `Redacted.Patterns` that mimics what was inside `NetworkLogger` itself and what was inside `NetworkLogger+Redacting`.

This way we can set separately `Redacted` struct onto the `NetworkLogger` and `LoggerStore` configurations and they would follow the same approach.

We can also set same `Redacted` for both if we'd like to follow the same logic in both.

Let me know what you think 🙏 