### PR TITLE
Disable "Report" & "Settings" options in prompts

### DIFF
--- a/Demo/Sources/iOS/Pulse_Demo_iOSApp.swift
+++ b/Demo/Sources/iOS/Pulse_Demo_iOSApp.swift
@@ -25,6 +25,13 @@ private final class AppViewModel: ObservableObject {
     init() {
         // This code registers the store with the `RemoteLogger` (important!)
         LoggerStore.shared = .demo
+        
+        /*
+            //Disable: options -> 1. "Settings", "Get Pulse Pro", "Report Issue"
+        UserDefaults.standard.set(true, forKey: "pulse-disable-support-prompts")
+        UserDefaults.standard.set(true, forKey: "pulse-disable-report-issue-prompts")
+        UserDefaults.standard.set(true, forKey: "pulse-disable-settings-prompts")
+         */
 
         // RemoteLogger.shared.isAutomaticConnectionEnabled = true
 

--- a/Sources/PulseUI/Features/Console/Views/ConsoleContextMenu.swift
+++ b/Sources/PulseUI/Features/Console/Views/ConsoleContextMenu.swift
@@ -25,9 +25,12 @@ struct ConsoleContextMenu: View {
                 ConsoleSortByMenu()
             }
             Section {
-                Button(action: { router.isShowingSettings = true }) {
-                    Label("Settings", systemImage: "gear")
+                if !UserDefaults.standard.bool(forKey: "pulse-disable-settings-prompts") {
+                    Button(action: { router.isShowingSettings = true }) {
+                        Label("Settings", systemImage: "gear")
+                    }
                 }
+                
                 if !environment.store.options.contains(.readonly) {
                     Button(role: .destructive, action: environment.removeAllLogs) {
                         Label("Remove Logs", systemImage: "trash")
@@ -40,8 +43,10 @@ struct ConsoleContextMenu: View {
                         Label("Get Pulse Pro", systemImage: "link")
                     }
                 }
-                Button(action: buttonSendFeedbackTapped) {
-                    Label("Report Issue", systemImage: "envelope")
+                if !UserDefaults.standard.bool(forKey: "pulse-disable-report-issue-prompts") {
+                    Button(action: buttonSendFeedbackTapped) {
+                        Label("Report Issue", systemImage: "envelope")
+                    }
                 }
             }
         } label: {


### PR DESCRIPTION
- Easy to disable "Report" & "Settings" options in prompts

```swift
UserDefaults.standard.set(true, forKey: "pulse-disable-support-prompts")
UserDefaults.standard.set(true, forKey: "pulse-disable-report-issue-prompts")
UserDefaults.standard.set(true, forKey: "pulse-disable-settings-prompts")
```

![Screenshot 2025-04-09 at 9 17 13 PM](https://github.com/user-attachments/assets/e827bc81-4baa-4995-945d-2403ff65e4d6)
