### PR TITLE
Handle InputStream.read failures

### DIFF
--- a/Sources/Pulse/Helpers/Helpers.swift
+++ b/Sources/Pulse/Helpers/Helpers.swift
@@ -88,6 +88,7 @@ extension URLRequest {
         var bodyStreamData = Data()
         while bodyStream.hasBytesAvailable {
             let readData = bodyStream.read(buffer, maxLength: bufferSize)
+            guard readData != 1 else { return nil } // read failed
             bodyStreamData.append(buffer, count: readData)
         }
         return bodyStreamData

--- a/Sources/Pulse/Helpers/Helpers.swift
+++ b/Sources/Pulse/Helpers/Helpers.swift
@@ -88,7 +88,7 @@ extension URLRequest {
         var bodyStreamData = Data()
         while bodyStream.hasBytesAvailable {
             let readData = bodyStream.read(buffer, maxLength: bufferSize)
-            guard readData != 1 else { return nil } // read failed
+            guard readData != -1 else { return nil } // read failed
             bodyStreamData.append(buffer, count: readData)
         }
         return bodyStreamData


### PR DESCRIPTION
`InputStream.read` can fail and return -1 (see the [docs](https://developer.apple.com/documentation/foundation/inputstream/read(_:maxlength:))). If this happens, the `bodyStreamData.append` call currently crashes with an `EXC_BAD_ACCESS` since we pass `count: -1`. We can fix this by explicitly checking for a return value of -1 and bailing.