### PR TITLE
Fix crash on AVAssetDownloadTask swizzling

### DIFF
--- a/Sources/Pulse/NetworkLogger/NetworkLogger.swift
+++ b/Sources/Pulse/NetworkLogger/NetworkLogger.swift
@@ -2,6 +2,7 @@
 //
 // Copyright (c) 2020-2024 Alexander Grebenyuk (github.com/kean).
 
+import AVFoundation
 import Foundation
 
 /// A wrapper on top of ``LoggerStore`` that simplifies logging of network requests.
@@ -167,6 +168,7 @@ public final class NetworkLogger: @unchecked Sendable {
         let context = context(for: task)
         lock.unlock()
 
+        guard !task.isKind(of: AVAssetDownloadTask.self) else { return }
         guard let originalRequest = task.originalRequest else { return }
         send(.networkTaskCreated(LoggerStore.Event.NetworkTaskCreated(
             taskId: context.taskId,


### PR DESCRIPTION
Hello there!
I found a related [issue](https://github.com/kean/Pulse/issues/330) with a crash involving `AVAssetDownloadTask`
I’ve faced a similar problem when downloading HLS videos and using `NetworkLogger.enableProxy()`
It seems to be an Apple inheritance issue — for some reason, `AVAssetDownloadTask` doesn’t support `originalRequest`
So, I’ve decided to skip this check for `AVAssetDownloadTask`
What do you think?