### PR TITLE
feat: make logs sharing API public

### DIFF
--- a/Sources/PulseUI/Helpers/ShareItems.swift
+++ b/Sources/PulseUI/Helpers/ShareItems.swift
@@ -28,11 +28,11 @@ public enum ShareStoreOutput: String, RawRepresentable, Codable, CaseIterable {
     }
 }
 
-package struct ShareItems: Identifiable {
-    package let id = UUID()
-    package let items: [Any]
-    package let size: Int64?
-    package let cleanup: () -> Void
+public struct ShareItems: Identifiable {
+    public let id = UUID()
+    public let items: [Any]
+    public let size: Int64?
+    public let cleanup: () -> Void
 
     package init(_ items: [Any], size: Int64? = nil, cleanup: @escaping () -> Void = { }) {
         self.items = items
@@ -41,10 +41,8 @@ package struct ShareItems: Identifiable {
     }
 }
 
-package enum ShareService {
-    private static var task: ShareStoreTask?
-
-    package static func share(_ entities: [NSManagedObject], store: LoggerStore, as output: ShareOutput) async throws -> ShareItems {
+public enum ShareService {
+    public static func share(_ entities: [NSManagedObject], store: LoggerStore, as output: ShareOutput) async throws -> ShareItems {
         try await withUnsafeThrowingContinuation { continuation in
             ShareStoreTask(entities: entities, store: store, output: output) {
                 if let value = $0 {
@@ -56,12 +54,12 @@ package enum ShareService {
         }
     }
 
-    package static func share(_ message: LoggerMessageEntity, as output: ShareOutput) -> ShareItems {
+    public static func share(_ message: LoggerMessageEntity, as output: ShareOutput) -> ShareItems {
         let string = TextRenderer(options: .sharing).make { $0.render(message) }
         return share(string, as: output)
     }
 
-    package static func share(_ task: NetworkTaskEntity, as output: ShareOutput, store: LoggerStore) -> ShareItems {
+    public static func share(_ task: NetworkTaskEntity, as output: ShareOutput, store: LoggerStore) -> ShareItems {
         let string = TextRenderer(options: .sharing).make { $0.render(task, content: .sharing, store: store) }
         return share(string, as: output)
     }


### PR DESCRIPTION
This **PR** enables developers to export Pulse logs through a low-level API. Specifically, it changes the access level of `ShareItems` and `ShareService` from **package -> public**.

**Context**

I’m using Pulse in my app and want to allow end users to export device logs by tapping a button on the troubleshooting screen. To make this process as seamless as possible—and to avoid the overhead of integrating PulseUI screens for export - I’d prefer a lightweight, low-level way to access and share logs.