### PR TITLE
fix: Add watchOS to AVAssetDownloadTask availability check

### DIFF
--- a/Sources/Pulse/NetworkLogger/NetworkLogger.swift
+++ b/Sources/Pulse/NetworkLogger/NetworkLogger.swift
@@ -168,7 +168,9 @@ public final class NetworkLogger: @unchecked Sendable {
         let context = context(for: task)
         lock.unlock()
 
+#if !os(tvOS) && !os(watchOS)
         guard !task.isKind(of: AVAssetDownloadTask.self) else { return }
+#endif
         guard let originalRequest = task.originalRequest else { return }
         send(.networkTaskCreated(LoggerStore.Event.NetworkTaskCreated(
             taskId: context.taskId,


### PR DESCRIPTION
 ## Summary

  Fix build failures on tvOS and watchOS platforms caused by `AVAssetDownloadTask` unavailability.

  ## Problem

  The recent upstream commit (6dff47cd) added a check to filter out `AVAssetDownloadTask` to prevent crashes during
  swizzling. However, `AVAssetDownloadTask` is only available on iOS and macOS, causing compilation errors on tvOS and
   watchOS:

  ❌ 'AVAssetDownloadTask' is unavailable in tvOS
  ❌ 'AVAssetDownloadTask' is unavailable in watchOS

  ## Solution

  Added platform-specific conditional compilation to exclude the `AVAssetDownloadTask` check on tvOS and watchOS:

  ```swift
  #if !os(tvOS) && !os(watchOS)
      guard !task.isKind(of: AVAssetDownloadTask.self) else { return }
  #endif

  Why This Is Safe

  1. tvOS/watchOS: AVAssetDownloadTask doesn't exist on these platforms, so no such tasks will ever be created. The
  check can be safely skipped.
  2. iOS/macOS: The check remains in place to prevent crashes when encountering AVAssetDownloadTask instances (used
  for HLS streaming).

  Testing

  - ✅ Builds successfully on all platforms (iOS, tvOS, watchOS, macOS)
  - ✅ No functional changes for iOS/macOS
  - ✅ Fixes compilation errors on tvOS/watchOS

  Related Issues

  - Fixes build failures in CI/CD pipelines for tvOS and watchOS targets
  - Maintains compatibility with the upstream fix for AVAssetDownloadTask crash (commit 6dff47cd)