### PR TITLE
Making `URLSessionProtocol` conform to `Sendable` in Swift 6

### DIFF
--- a/Sources/Pulse/URLSessionProxy/URLSessionProtocol.swift
+++ b/Sources/Pulse/URLSessionProxy/URLSessionProtocol.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public protocol URLSessionProtocol {
+public protocol URLSessionProtocol: Sendable {
     // MARK: - Core
 
     func dataTask(with request: URLRequest) -> URLSessionDataTask

--- a/Sources/Pulse/URLSessionProxy/URLSessionProtocol.swift
+++ b/Sources/Pulse/URLSessionProxy/URLSessionProtocol.swift
@@ -3,8 +3,12 @@
 // Copyright (c) 2020-2024 Alexander Grebenyuk (github.com/kean).
 
 import Foundation
-
-public protocol URLSessionProtocol: Sendable {
+#if swift(>=6.0)
+public typealias SendableIfSwift6 = Sendable
+#else
+public protocol SendableIfSwift6 {}
+#endif
+public protocol URLSessionProtocol: SendableIfSwift6 {
     // MARK: - Core
 
     func dataTask(with request: URLRequest) -> URLSessionDataTask


### PR DESCRIPTION
Conditionally adding conformance to the `Sendable` if the version of `Swift` is 6 or higher. 
This conforming allow to use this protocol in the new Swift Concurrency APIs.