### PR TITLE
Conforming `URLSessionProtocol` to `Sendable`

### DIFF
--- a/Sources/Pulse/URLSessionProxy/URLSessionProtocol.swift
+++ b/Sources/Pulse/URLSessionProxy/URLSessionProtocol.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public protocol URLSessionProtocol {
+public protocol URLSessionProtocol: Sendable {
     // MARK: - Core
 
     func dataTask(with request: URLRequest) -> URLSessionDataTask


### PR DESCRIPTION
This PR marks the `URLSessionProtocol` conforming to Swift 6 Concurrency. Therefore projects that are running on Swift 6 can adapt to this protocol without any issue.