### PR TITLE
Fix: crash while clearing logs caused by _unconditionallyBridgeFromObjectiveC UUID

### DIFF
--- a/Sources/Pulse/LoggerStore/LoggerStore+Entities.swift
+++ b/Sources/Pulse/LoggerStore/LoggerStore+Entities.swift
@@ -31,7 +31,7 @@ public final class NetworkTaskEntity: NSManagedObject {
     // Primary
     @NSManaged public var createdAt: Date
     @NSManaged public var isPinned: Bool
-    @NSManaged public var session: UUID
+    @NSManaged public var session: UUID?
     @NSManaged public var taskId: UUID
 
     /// Returns task type


### PR DESCRIPTION
### Issue
https://github.com/kean/Pulse/issues/349

### Goals
Fix crash when comparing two UUIDs, one of which is in a `NSManagedObject`.

I discovered that under the hood `_unconditionallyBridgeFromObjectiveC` forces NSUUID with `!`. Reference [UUID_Wrappers.swift](https://github.com/swiftlang/swift-foundation/blob/main/Sources/FoundationEssentials/UUID_Wrappers.swift#L51)
```swift
@_effects(readonly)
public static func _unconditionallyBridgeFromObjectiveC(_ source: NSUUID?) -> UUID {
    var result: UUID?
     _forceBridgeFromObjectiveC(source!, result: &result)
    return result!
}
```

```swift
package func state(in store: LoggerStore?) -> NetworkTaskEntity.State? {
    let state = self.state
    if state == .pending, let store, self.session != store.session.id { //👈 💥 crash here
        return nil
    }
    return state
}
```

This could be an issue if the object is in the process of being deleted but still has reference(s), as indicated in the issue above.