### PR TITLE
feat: Add WebSocket support for URLSession, Starscream, and Apollo

### DIFF
--- a/Demo/Pulse.xcodeproj/project.pbxproj
+++ b/Demo/Pulse.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		0C6460DE25F579B8002C55B1 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0C6460D925F579B8002C55B1 /* Preview Assets.xcassets */; };
 		0C6460DF25F579B8002C55B1 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C6460DA25F579B8002C55B1 /* ContentView.swift */; };
 		0C70EA762A3F611B000B1071 /* Pulse_Demo_iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C70EA752A3F611B000B1071 /* Pulse_Demo_iOSApp.swift */; };
+		0C70EA772A3F611B000B1072 /* WebSocketDemoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C70EA782A3F611B000B1072 /* WebSocketDemoView.swift */; };
 		0C70EA7A2A3F611C000B1071 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0C70EA792A3F611C000B1071 /* Assets.xcassets */; };
 		0C70EA812A3F6190000B1071 /* repos.json in Resources */ = {isa = PBXBuildFile; fileRef = 0CDACDE129EC6607007C15CD /* repos.json */; };
 		0C8FCB502C45F05400C4FD84 /* Pulse in Frameworks */ = {isa = PBXBuildFile; productRef = 0C8FCB4F2C45F05400C4FD84 /* Pulse */; };
@@ -34,6 +35,7 @@
 		0C8FCB742C45F12900C4FD84 /* MockTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8FCB692C45F12900C4FD84 /* MockTask.swift */; };
 		0C8FCB752C45F12900C4FD84 /* MockTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8FCB692C45F12900C4FD84 /* MockTask.swift */; };
 		0CA245732C85E87A00B432DA /* PulseProxy in Frameworks */ = {isa = PBXBuildFile; productRef = 0CA245722C85E87A00B432DA /* PulseProxy */; };
+		0CA245742C85E87A00B432DB /* PulseStarscream in Frameworks */ = {isa = PBXBuildFile; productRef = 0CA245752C85E87A00B432DB /* PulseStarscream */; };
 		0CDACDE629EC6607007C15CD /* repos.json in Resources */ = {isa = PBXBuildFile; fileRef = 0CDACDE129EC6607007C15CD /* repos.json */; };
 /* End PBXBuildFile section */
 
@@ -92,6 +94,7 @@
 		0C6460DB25F579B8002C55B1 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		0C70EA732A3F611B000B1071 /* Pulse Demo iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Pulse Demo iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		0C70EA752A3F611B000B1071 /* Pulse_Demo_iOSApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pulse_Demo_iOSApp.swift; sourceTree = "<group>"; };
+		0C70EA782A3F611B000B1072 /* WebSocketDemoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSocketDemoView.swift; sourceTree = "<group>"; };
 		0C70EA792A3F611C000B1071 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		0C8CD5922A86F527003D116E /* Pulse-Demo-iOS-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Pulse-Demo-iOS-Info.plist"; sourceTree = "<group>"; };
 		0C8CD5932A86F581003D116E /* Pulse-Demo-macOS-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Pulse-Demo-macOS-Info.plist"; sourceTree = "<group>"; };
@@ -131,6 +134,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0CA245732C85E87A00B432DA /* PulseProxy in Frameworks */,
+				0CA245742C85E87A00B432DB /* PulseStarscream in Frameworks */,
 				0C8FCB522C45F05400C4FD84 /* PulseUI in Frameworks */,
 				0C8FCB502C45F05400C4FD84 /* Pulse in Frameworks */,
 			);
@@ -245,6 +249,7 @@
 			isa = PBXGroup;
 			children = (
 				0C70EA752A3F611B000B1071 /* Pulse_Demo_iOSApp.swift */,
+				0C70EA782A3F611B000B1072 /* WebSocketDemoView.swift */,
 				0C70EA792A3F611C000B1071 /* Assets.xcassets */,
 			);
 			path = iOS;
@@ -332,6 +337,7 @@
 				0C8FCB4F2C45F05400C4FD84 /* Pulse */,
 				0C8FCB512C45F05400C4FD84 /* PulseUI */,
 				0CA245722C85E87A00B432DA /* PulseProxy */,
+				0CA245752C85E87A00B432DB /* PulseStarscream */,
 			);
 			productName = "Pulse Demo iOS";
 			productReference = 0C70EA732A3F611B000B1071 /* Pulse Demo iOS.app */;
@@ -369,6 +375,7 @@
 			);
 			mainGroup = 0C57AD44245F0EFB005B3400;
 			packageReferences = (
+				0C8FCB4E2C45F05400C4FD83 /* XCLocalSwiftPackageReference "../" */,
 			);
 			productRefGroup = 0C57AD4E245F0EFB005B3400 /* Products */;
 			projectDirPath = "";
@@ -443,6 +450,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0C70EA762A3F611B000B1071 /* Pulse_Demo_iOSApp.swift in Sources */,
+				0C70EA772A3F611B000B1072 /* WebSocketDemoView.swift in Sources */,
 				0C8FCB702C45F12900C4FD84 /* MockTask.swift in Sources */,
 				0C8FCB6A2C45F12900C4FD84 /* MockStore.swift in Sources */,
 			);
@@ -803,33 +811,52 @@
 /* Begin XCSwiftPackageProductDependency section */
 		0C8FCB4F2C45F05400C4FD84 /* Pulse */ = {
 			isa = XCSwiftPackageProductDependency;
+			package = 0C8FCB4E2C45F05400C4FD83 /* XCLocalSwiftPackageReference "../" */;
 			productName = Pulse;
 		};
 		0C8FCB512C45F05400C4FD84 /* PulseUI */ = {
 			isa = XCSwiftPackageProductDependency;
+			package = 0C8FCB4E2C45F05400C4FD83 /* XCLocalSwiftPackageReference "../" */;
 			productName = PulseUI;
 		};
 		0C8FCB5F2C45F06300C4FD84 /* Pulse */ = {
 			isa = XCSwiftPackageProductDependency;
+			package = 0C8FCB4E2C45F05400C4FD83 /* XCLocalSwiftPackageReference "../" */;
 			productName = Pulse;
 		};
 		0C8FCB612C45F06300C4FD84 /* PulseUI */ = {
 			isa = XCSwiftPackageProductDependency;
+			package = 0C8FCB4E2C45F05400C4FD83 /* XCLocalSwiftPackageReference "../" */;
 			productName = PulseUI;
 		};
 		0C8FCB632C45F06900C4FD84 /* Pulse */ = {
 			isa = XCSwiftPackageProductDependency;
+			package = 0C8FCB4E2C45F05400C4FD83 /* XCLocalSwiftPackageReference "../" */;
 			productName = Pulse;
 		};
 		0C8FCB652C45F06900C4FD84 /* PulseUI */ = {
 			isa = XCSwiftPackageProductDependency;
+			package = 0C8FCB4E2C45F05400C4FD83 /* XCLocalSwiftPackageReference "../" */;
 			productName = PulseUI;
 		};
 		0CA245722C85E87A00B432DA /* PulseProxy */ = {
 			isa = XCSwiftPackageProductDependency;
+			package = 0C8FCB4E2C45F05400C4FD83 /* XCLocalSwiftPackageReference "../" */;
 			productName = PulseProxy;
 		};
+		0CA245752C85E87A00B432DB /* PulseStarscream */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 0C8FCB4E2C45F05400C4FD83 /* XCLocalSwiftPackageReference "../" */;
+			productName = PulseStarscream;
+		};
 /* End XCSwiftPackageProductDependency section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		0C8FCB4E2C45F05400C4FD83 /* XCLocalSwiftPackageReference "../" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = "../";
+		};
+/* End XCLocalSwiftPackageReference section */
 	};
 	rootObject = 0C57AD45245F0EFB005B3400 /* Project object */;
 }

--- a/Demo/Sources/iOS/Pulse_Demo_iOSApp.swift
+++ b/Demo/Sources/iOS/Pulse_Demo_iOSApp.swift
@@ -13,8 +13,20 @@ struct PulseDemo_iOS: App {
 
     var body: some Scene {
         WindowGroup {
-            NavigationView {
-                ConsoleView(store: .demo)
+            TabView {
+                NavigationView {
+                    WebSocketDemoView()
+                }
+                .tabItem {
+                    Label("WebSocket", systemImage: "arrow.up.arrow.down.circle")
+                }
+                
+                NavigationView {
+                    ConsoleView(store: .shared)
+                }
+                .tabItem {
+                    Label("Console", systemImage: "list.bullet.rectangle")
+                }
             }
         }
     }
@@ -23,73 +35,7 @@ struct PulseDemo_iOS: App {
 @MainActor
 private final class AppViewModel: ObservableObject {
     init() {
-        // This code registers the store with the `RemoteLogger` (important!)
+        // Use shared store for demo
         LoggerStore.shared = .demo
-        
-        /*
-            //Disable: options -> 1. "Settings", "Get Pulse Pro", "Report Issue"
-        UserDefaults.standard.set(true, forKey: "pulse-disable-support-prompts")
-        UserDefaults.standard.set(true, forKey: "pulse-disable-report-issue-prompts")
-        UserDefaults.standard.set(true, forKey: "pulse-disable-settings-prompts")
-         */
-
-        // RemoteLogger.shared.isAutomaticConnectionEnabled = true
-
-        // NetworkLogger.enableProxy()
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(3)) {
-            sendRequest()
-        }
-    }
-}
-
-
-private func sendRequest() {
-     // testClosures()
-    // testSwiftConcurrency()
-}
-
-private func testClosures() {
-    let session = URLSessionProxy(configuration: .default)
-    let dataTask = session.dataTask(with: URLRequest(url: URL(string: "https://api.github.com/repos/octocat/Spoon-Knife/issues?per_page=2")!)) { data, _, _ in
-        NSLog("didFinish: \(data?.count ?? 0)")
-    }
-    dataTask.resume()
-
-    let downloadTask = session.downloadTask(with: URLRequest(url: URL(string: "https://api.github.com/repos/octocat/Spoon-Knife/issues?per_page=2")!)) { url, _, _ in
-        NSLog("didFinish: \(String(describing: url))")
-    }
-    downloadTask.resume()
-}
-
-private func testSwiftConcurrency() {
-    Task {
-        let demoDelegate = DemoSessionDelegate()
-        let session = URLSessionProxy(configuration: .default, delegate: demoDelegate, delegateQueue: nil)
-//        let session = URLSession(configuration: .default)
-
-        let (data, _) = try await session.data(from: URL(string: "https://api.github.com/repos/octocat/Spoon-Knife/issues?per_page=2")!)
-        NSLog("didFinish: \(data.count)")
-    }
-
-    Task {
-        let session = URLSessionProxy(configuration: .default)
-
-        let (url, _) = try await session.download(from: URL(string: "https://api.github.com/repos/octocat/Spoon-Knife/issues?per_page=2")!, delegate: nil)
-        NSLog("didFinish: \(url)")
-    }
-}
-
-private final class DemoSessionDelegate: NSObject, URLSessionDelegate, URLSessionDataDelegate {
-    func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
-        NSLog("[\(dataTask.taskIdentifier)] didReceive: \(data.count)")
-    }
-
-    func urlSession(_ session: URLSession, task: URLSessionTask, didFinishCollecting metrics: URLSessionTaskMetrics) {
-        NSLog("[\(task.taskIdentifier)] didFinishCollectingMetrics: \(metrics)")
-    }
-
-    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: (any Error)?) {
-        NSLog("[\(task.taskIdentifier)] didCompleteWithError: \(String(describing: error))")
     }
 }

--- a/Demo/Sources/iOS/WebSocketDemoView.swift
+++ b/Demo/Sources/iOS/WebSocketDemoView.swift
@@ -1,0 +1,362 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020-2024 Alexander Grebenyuk (github.com/kean).
+
+import SwiftUI
+import Pulse
+import PulseUI
+import PulseProxy
+import PulseStarscream
+import Starscream
+
+// MARK: - Main Demo View
+
+struct WebSocketDemoView: View {
+    @State private var urlSessionStatus = "Not connected"
+    @State private var starscreamStatus = "Not connected"
+    @State private var apolloStatus = "Not connected"
+    @State private var showConsole = false
+    
+    var body: some View {
+        List {
+            Section("URLSession WebSocket") {
+                Text(urlSessionStatus)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                Button("Test URLSession WebSocket") {
+                    testURLSessionWebSocket()
+                }
+            }
+            
+            Section("Starscream WebSocket") {
+                Text(starscreamStatus)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                Button("Test Starscream WebSocket") {
+                    testStarscreamWebSocket()
+                }
+            }
+            
+            Section("Apollo WebSocket (Simulated)") {
+                Text(apolloStatus)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                Button("Test Apollo WebSocket Logging") {
+                    testApolloWebSocket()
+                }
+                Text("Note: Uses simulated events since Apollo requires a real GraphQL server")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
+            
+            Section("Actions") {
+                Button("View Pulse Console") {
+                    showConsole = true
+                }
+            }
+        }
+        .navigationTitle("WebSocket Demo")
+        .sheet(isPresented: $showConsole) {
+            NavigationView {
+                ConsoleView(store: .shared)
+                    .toolbar {
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Done") { showConsole = false }
+                        }
+                    }
+            }
+        }
+    }
+    
+    // MARK: - Apollo WebSocket Demo (Simulated)
+    
+    private func testApolloWebSocket() {
+        apolloStatus = "Simulating Apollo WebSocket..."
+        ApolloDemoManager.shared.simulateSubscription { status in
+            apolloStatus = status
+        }
+    }
+    
+    // MARK: - URLSession WebSocket Demo
+    
+    private func testURLSessionWebSocket() {
+        urlSessionStatus = "Connecting..."
+        
+        Task {
+            do {
+                // Use the public WebSocket echo server
+                guard let url = URL(string: "wss://echo.websocket.org") else {
+                    await MainActor.run { urlSessionStatus = "Invalid URL" }
+                    return
+                }
+                
+                // Create session with proxy for logging
+                let session = URLSessionProxy(configuration: .default)
+                let wsTask = session.webSocketTaskProxy(with: url)
+                wsTask.resume()
+                
+                await MainActor.run { urlSessionStatus = "Connected, sending message..." }
+                
+                // Send a text message
+                try await wsTask.send(.string("Hello from URLSession WebSocket!"))
+                
+                await MainActor.run { urlSessionStatus = "Message sent, waiting for echo..." }
+                
+                // Receive the echo
+                let message = try await wsTask.receive()
+                switch message {
+                case .string(let text):
+                    await MainActor.run { urlSessionStatus = "Received: \(text.prefix(50))..." }
+                case .data(let data):
+                    await MainActor.run { urlSessionStatus = "Received \(data.count) bytes" }
+                @unknown default:
+                    await MainActor.run { urlSessionStatus = "Received unknown message type" }
+                }
+                
+                // Send another message
+                try await wsTask.send(.string("{\"type\":\"test\",\"payload\":{\"id\":123,\"name\":\"Demo\"}}"))
+                let _ = try await wsTask.receive()
+                
+                // Close the connection
+                wsTask.cancel(with: .normalClosure, reason: nil)
+                
+                await MainActor.run { urlSessionStatus = "✅ Complete! Check Pulse console." }
+                
+            } catch {
+                await MainActor.run { urlSessionStatus = "Error: \(error.localizedDescription)" }
+            }
+        }
+    }
+    
+    // MARK: - Starscream WebSocket Demo
+    
+    private func testStarscreamWebSocket() {
+        starscreamStatus = "Connecting..."
+        StarscreamDemoManager.shared.connect { status in
+            starscreamStatus = status
+        }
+    }
+}
+
+// MARK: - Starscream Demo Manager
+
+/// Manages Starscream WebSocket connection for demo purposes
+final class StarscreamDemoManager: WebSocketDelegate {
+    static let shared = StarscreamDemoManager()
+    
+    private var socket: WebSocket?
+    private var logger: StarscreamLogger?
+    private var statusCallback: ((String) -> Void)?
+    private var messageCount = 0
+    
+    private init() {}
+    
+    func connect(statusCallback: @escaping (String) -> Void) {
+        self.statusCallback = statusCallback
+        self.messageCount = 0
+        
+        guard let url = URL(string: "wss://echo.websocket.org") else {
+            statusCallback("Invalid URL")
+            return
+        }
+        
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 10
+        
+        socket = WebSocket(request: request)
+        
+        // Enable Pulse logging - this is the key integration!
+        logger = socket?.enablePulseLogging(delegate: self)
+        
+        socket?.connect()
+    }
+    
+    // MARK: - WebSocketDelegate
+    
+    func didReceive(event: WebSocketEvent, client: any WebSocketClient) {
+        switch event {
+        case .connected:
+            statusCallback?("Connected! Sending messages...")
+            
+            // Send test messages
+            socket?.write(string: "Hello from Starscream!")
+            logger?.logSentText("Hello from Starscream!")
+            
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                let jsonMessage = "{\"type\":\"starscream_test\",\"data\":{\"id\":456,\"items\":[1,2,3]}}"
+                self?.socket?.write(string: jsonMessage)
+                self?.logger?.logSentText(jsonMessage)
+            }
+            
+        case .text(let text):
+            messageCount += 1
+            statusCallback?("Received \(messageCount) message(s): \(text.prefix(30))...")
+            
+            if messageCount >= 2 {
+                // Disconnect after receiving both echoes
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                    self?.socket?.disconnect()
+                    self?.statusCallback?("✅ Complete! Check Pulse console.")
+                }
+            }
+            
+        case .binary(let data):
+            statusCallback?("Received binary: \(data.count) bytes")
+            
+        case .disconnected(let reason, let code):
+            statusCallback?("Disconnected: \(reason) (code: \(code))")
+            
+        case .error(let error):
+            statusCallback?("Error: \(error?.localizedDescription ?? "unknown")")
+            
+        case .cancelled:
+            statusCallback?("Cancelled")
+            
+        case .ping, .pong, .viabilityChanged, .reconnectSuggested, .peerClosed:
+            break
+        }
+    }
+}
+
+// MARK: - Apollo Demo Manager
+
+/// Simulates Apollo WebSocket events for demo purposes
+/// In a real app, these events would come from actual GraphQL subscriptions
+final class ApolloDemoManager {
+    static let shared = ApolloDemoManager()
+    
+    private let taskId = UUID()
+    private let logger = NetworkLogger.shared
+    
+    private init() {}
+    
+    func simulateSubscription(statusCallback: @escaping (String) -> Void) {
+        // Create a mock URL for the simulated connection
+        guard let url = URL(string: "wss://api.example.com/graphql") else {
+            statusCallback("Invalid URL")
+            return
+        }
+        
+        statusCallback("Simulating connection...")
+        
+        // Simulate task creation
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        
+        logger.logEvent(.networkTaskCreated(.init(
+            taskId: taskId,
+            taskType: .webSocketTask,
+            createdAt: Date(),
+            originalRequest: NetworkLogger.Request(request),
+            currentRequest: nil,
+            label: "Apollo Demo",
+            taskDescription: "Simulated Apollo WebSocket"
+        )))
+        
+        // Simulate connection opened
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+            guard let self else { return }
+            
+            self.logger.logEvent(.webSocketTaskOpened(.init(
+                taskId: self.taskId,
+                createdAt: Date(),
+                protocol: "graphql-transport-ws"
+            )))
+            
+            // Log subscription start
+            let subscribeMessage = "{\"type\":\"subscribe\",\"payload\":{\"operationName\":\"UserNotifications\"}}"
+            self.logFrame(subscribeMessage, isSent: true)
+            statusCallback("Subscription started...")
+        }
+        
+        // Simulate receiving data
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) { [weak self] in
+            let mockPayload = """
+            {"type":"next","operation":"UserNotifications","data":{"notification":{"id":"123","title":"New Message","body":"You have a new notification","createdAt":"2024-12-24T15:00:00Z","read":false}}}
+            """
+            self?.logFrame(mockPayload, isSent: false)
+            statusCallback("Received notification...")
+        }
+        
+        // Simulate another data event
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.3) { [weak self] in
+            let mockPayload2 = """
+            {"type":"next","operation":"UserNotifications","data":{"notification":{"id":"124","title":"Order Update","body":"Your order has shipped!","createdAt":"2024-12-24T15:01:00Z","read":false,"metadata":{"orderId":"ORD-9876","carrier":"FedEx"}}}}
+            """
+            self?.logFrame(mockPayload2, isSent: false)
+            statusCallback("Received order update...")
+        }
+        
+        // Complete
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.8) { [weak self] in
+            guard let self else { return }
+            
+            self.logFrame("{\"type\":\"complete\",\"operation\":\"UserNotifications\"}", isSent: false)
+            
+            self.logger.logEvent(.webSocketTaskClosed(.init(
+                taskId: self.taskId,
+                createdAt: Date(),
+                closeCode: 1000,
+                reason: Data("Normal closure".utf8)
+            )))
+            
+            statusCallback("✅ Complete! Check Pulse console.")
+        }
+    }
+    
+    private func logFrame(_ message: String, isSent: Bool) {
+        let frame = LoggerStore.Event.WebSocketFrame(
+            taskId: taskId,
+            createdAt: Date(),
+            frameType: .text,
+            data: Data(message.utf8),
+            isTruncated: false
+        )
+        
+        if isSent {
+            logger.logEvent(.webSocketFrameSent(frame))
+        } else {
+            logger.logEvent(.webSocketFrameReceived(frame))
+        }
+    }
+}
+
+// MARK: - Global test function (called from app startup)
+
+func testWebSocket() {
+    // This is called on app startup - run a quick URLSession WebSocket test
+    Task {
+        do {
+            guard let url = URL(string: "wss://echo.websocket.org") else { return }
+            
+            let session = URLSessionProxy(configuration: .default)
+            let wsTask = session.webSocketTaskProxy(with: url)
+            wsTask.resume()
+            
+            // Wait a moment for connection
+            try await Task.sleep(nanoseconds: 1_000_000_000)
+            
+            // Send and receive
+            try await wsTask.send(.string("Auto-test from Pulse Demo"))
+            let _ = try await wsTask.receive()
+            
+            wsTask.cancel(with: .normalClosure, reason: nil)
+            
+            NSLog("WebSocket auto-test completed successfully")
+        } catch {
+            NSLog("WebSocket auto-test error: \(error)")
+        }
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+struct WebSocketDemoView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            WebSocketDemoView()
+        }
+    }
+}
+#endif

--- a/Package.swift
+++ b/Package.swift
@@ -13,12 +13,24 @@ let package = Package(
     products: [
         .library(name: "Pulse", targets: ["Pulse"]),
         .library(name: "PulseProxy", targets: ["PulseProxy"]),
-        .library(name: "PulseUI", targets: ["PulseUI"])
+        .library(name: "PulseUI", targets: ["PulseUI"]),
+        .library(name: "PulseStarscream", targets: ["PulseStarscream"]),
+        .library(name: "PulseApollo", targets: ["PulseApollo"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/daltoniam/Starscream.git", from: "4.0.0"),
+        .package(url: "https://github.com/apollographql/apollo-ios.git", from: "1.0.0")
     ],
     targets: [
         .target(name: "Pulse"),
         .target(name: "PulseProxy", dependencies: ["Pulse"]),
         .target(name: "PulseUI", dependencies: ["Pulse"]),
+        .target(name: "PulseStarscream", dependencies: ["Pulse", "Starscream"]),
+        .target(name: "PulseApollo", dependencies: [
+            "Pulse",
+            .product(name: "ApolloWebSocket", package: "apollo-ios"),
+            .product(name: "ApolloAPI", package: "apollo-ios")
+        ]),
     ],
     swiftLanguageVersions: [
       .v5

--- a/Sources/Pulse/LoggerStore/LoggerStore+Entities.swift
+++ b/Sources/Pulse/LoggerStore/LoggerStore+Entities.swift
@@ -100,6 +100,17 @@ public final class NetworkTaskEntity: NSManagedObject {
     /// Associated (technical) message.
     @NSManaged public var message: LoggerMessageEntity?
 
+    // MARK: WebSocket
+
+    /// WebSocket frames associated with this task (only for WebSocket tasks).
+    @NSManaged public var webSocketFrames: Set<WebSocketFrameEntity>
+    /// The protocol negotiated during WebSocket handshake.
+    @NSManaged public var webSocketProtocol: String?
+    /// WebSocket close code (if closed).
+    @NSManaged public var webSocketCloseCode: Int16
+    /// WebSocket close reason (if closed).
+    @NSManaged public var webSocketCloseReason: Data?
+
     // MARK: Helpers
 
     public lazy var metadata = { rawMetadata.map(KeyValueEncoding.decodeKeyValuePairs) }()
@@ -142,6 +153,50 @@ public final class NetworkTaskEntity: NSManagedObject {
     public var decodingError: NetworkLogger.DecodingError? {
         error as? NetworkLogger.DecodingError
     }
+
+    public var orderedWebSocketFrames: [WebSocketFrameEntity] {
+        webSocketFrames.sorted { $0.createdAt < $1.createdAt }
+    }
+
+    public var isWebSocket: Bool {
+        type == .webSocketTask
+    }
+}
+
+/// Represents a WebSocket frame (sent or received).
+public final class WebSocketFrameEntity: NSManagedObject {
+    /// The timestamp when the frame was sent or received.
+    @NSManaged public var createdAt: Date
+    /// The task this frame belongs to.
+    @NSManaged public var task: NetworkTaskEntity
+    /// The direction of the frame: 0 = sent, 1 = received.
+    @NSManaged public var direction: Int16
+    /// The frame type: 0 = text, 1 = binary, 2 = ping, 3 = pong.
+    @NSManaged public var frameType: Int16
+    /// The payload size in bytes.
+    @NSManaged public var payloadSize: Int64
+    /// The payload data handle (for larger payloads).
+    @NSManaged public var payload: LoggerBlobHandleEntity?
+
+    /// Direction of the WebSocket frame.
+    @frozen public enum Direction: Int16 {
+        case sent = 0
+        case received = 1
+    }
+
+    /// Returns the direction as an enum.
+    public var frameDirection: Direction {
+        Direction(rawValue: direction) ?? .sent
+    }
+
+    /// Returns the frame type as an enum.
+    public var type: LoggerStore.Event.WebSocketFrame.FrameType {
+        LoggerStore.Event.WebSocketFrame.FrameType(rawValue: frameType) ?? .text
+    }
+}
+
+extension WebSocketFrameEntity: Identifiable {
+    public var id: NSManagedObjectID { objectID }
 }
 
 /// Indicates current download or upload progress.

--- a/Sources/Pulse/LoggerStore/LoggerStore+Event.swift
+++ b/Sources/Pulse/LoggerStore/LoggerStore+Event.swift
@@ -11,6 +11,10 @@ extension LoggerStore {
         case networkTaskCreated(NetworkTaskCreated)
         case networkTaskProgressUpdated(NetworkTaskProgressUpdated)
         case networkTaskCompleted(NetworkTaskCompleted)
+        case webSocketTaskOpened(WebSocketTaskOpened)
+        case webSocketTaskClosed(WebSocketTaskClosed)
+        case webSocketFrameSent(WebSocketFrame)
+        case webSocketFrameReceived(WebSocketFrame)
 
         public struct MessageCreated: Codable, Sendable {
             public var createdAt: Date
@@ -138,6 +142,66 @@ extension LoggerStore {
             }
         }
 
+        // MARK: - WebSocket Events
+
+        public struct WebSocketTaskOpened: Codable, Sendable {
+            public var taskId: UUID
+            public var createdAt: Date
+            public var `protocol`: String?
+
+            public init(taskId: UUID, createdAt: Date, protocol: String?) {
+                self.taskId = taskId
+                self.createdAt = createdAt
+                self.protocol = `protocol`
+            }
+        }
+
+        public struct WebSocketTaskClosed: Codable, Sendable {
+            public var taskId: UUID
+            public var createdAt: Date
+            public var closeCode: Int
+            public var reason: Data?
+
+            public init(taskId: UUID, createdAt: Date, closeCode: Int, reason: Data?) {
+                self.taskId = taskId
+                self.createdAt = createdAt
+                self.closeCode = closeCode
+                self.reason = reason
+            }
+        }
+
+        public struct WebSocketFrame: Codable, Sendable {
+            public var taskId: UUID
+            public var createdAt: Date
+            public var frameType: FrameType
+            public var data: Data?
+            public var isTruncated: Bool
+
+            public init(taskId: UUID, createdAt: Date, frameType: FrameType, data: Data?, isTruncated: Bool = false) {
+                self.taskId = taskId
+                self.createdAt = createdAt
+                self.frameType = frameType
+                self.data = data
+                self.isTruncated = isTruncated
+            }
+
+            @frozen public enum FrameType: Int16, Codable, Sendable {
+                case text = 0
+                case binary = 1
+                case ping = 2
+                case pong = 3
+
+                public var description: String {
+                    switch self {
+                    case .text: return "Text"
+                    case .binary: return "Binary"
+                    case .ping: return "Ping"
+                    case .pong: return "Pong"
+                    }
+                }
+            }
+        }
+
         var url: URL? {
             switch self {
             case .messageStored:
@@ -148,6 +212,8 @@ extension LoggerStore {
                 return event.url
             case .networkTaskCompleted(let event):
                 return event.originalRequest.url
+            case .webSocketTaskOpened, .webSocketTaskClosed, .webSocketFrameSent, .webSocketFrameReceived:
+                return nil // WebSocket frames don't carry URL; the parent task does
             }
         }
     }

--- a/Sources/Pulse/LoggerStore/LoggerStore+Model.swift
+++ b/Sources/Pulse/LoggerStore/LoggerStore+Model.swift
@@ -21,6 +21,7 @@ extension LoggerStore {
         let response = Entity(class: NetworkResponseEntity.self)
         let transaction = Entity(class: NetworkTransactionMetricsEntity.self)
         let blob = Entity(class: LoggerBlobHandleEntity.self)
+        let webSocketFrame = Entity(class: WebSocketFrameEntity.self)
 
         session.properties = [
             Attribute("id", .UUIDAttributeType),
@@ -75,7 +76,12 @@ extension LoggerStore {
             Relationship("message", .oneToOne(), entity: message),
             Relationship("requestBody", .oneToOne(isOptional: true), deleteRule: .noActionDeleteRule, entity: blob),
             Relationship("responseBody", .oneToOne(isOptional: true), deleteRule: .noActionDeleteRule, entity: blob),
-            Relationship("progress", .oneToOne(isOptional: true), entity: progress)
+            Relationship("progress", .oneToOne(isOptional: true), entity: progress),
+            // WebSocket properties
+            Relationship("webSocketFrames", .oneToMany, entity: webSocketFrame),
+            Attribute("webSocketProtocol", .stringAttributeType) { $0.isOptional = true },
+            Attribute("webSocketCloseCode", .integer16AttributeType),
+            Attribute("webSocketCloseReason", .binaryDataAttributeType) { $0.isOptional = true }
         ]
 
         request.properties = [
@@ -148,8 +154,17 @@ extension LoggerStore {
             Attribute("isUncompressed", .booleanAttributeType)
         ]
 
+        webSocketFrame.properties = [
+            Attribute("createdAt", .dateAttributeType),
+            Relationship("task", .oneToOne(), entity: task),
+            Attribute("direction", .integer16AttributeType),
+            Attribute("frameType", .integer16AttributeType),
+            Attribute("payloadSize", .integer64AttributeType),
+            Relationship("payload", .oneToOne(isOptional: true), deleteRule: .noActionDeleteRule, entity: blob)
+        ]
+
         let model = NSManagedObjectModel()
-        model.entities = [session, message, task, progress, blob, request, response, transaction]
+        model.entities = [session, message, task, progress, blob, request, response, transaction, webSocketFrame]
         return model
     }()
 }

--- a/Sources/Pulse/LoggerStore/LoggerStore.swift
+++ b/Sources/Pulse/LoggerStore/LoggerStore.swift
@@ -352,6 +352,10 @@ extension LoggerStore {
         case .networkTaskCreated(let event): process(event)
         case .networkTaskProgressUpdated(let event): process(event)
         case .networkTaskCompleted(let event): process(event)
+        case .webSocketTaskOpened(let event): process(event)
+        case .webSocketTaskClosed(let event): process(event)
+        case .webSocketFrameSent(let event): process(event, direction: .sent)
+        case .webSocketFrameReceived(let event): process(event, direction: .received)
         }
     }
 
@@ -492,6 +496,54 @@ extension LoggerStore {
         requestsCache = [:]
         responsesCache = [:]
         tasksCache[event.taskId] = nil
+    }
+
+    // MARK: - WebSocket Event Processing
+
+    private func process(_ event: Event.WebSocketTaskOpened) {
+        guard let task = findTask(forTaskId: event.taskId) else {
+            return // Task must exist before we can process WebSocket events
+        }
+        task.webSocketProtocol = event.protocol
+        // Update the task state to indicate the WebSocket is open/connected
+        task.requestState = NetworkTaskEntity.State.success.rawValue
+        task.startDate = event.createdAt
+    }
+
+    private func process(_ event: Event.WebSocketTaskClosed) {
+        guard let task = findTask(forTaskId: event.taskId) else {
+            return
+        }
+        task.webSocketCloseCode = Int16(event.closeCode)
+        task.webSocketCloseReason = event.reason
+        // Mark task as completed
+        task.duration = event.createdAt.timeIntervalSince(task.startDate ?? task.createdAt)
+
+        // Update associated message
+        if let message = task.message {
+            message.line = Int32(task.requestState)
+        }
+    }
+
+    private func process(_ event: Event.WebSocketFrame, direction: WebSocketFrameEntity.Direction) {
+        guard let task = findTask(forTaskId: event.taskId) else {
+            return
+        }
+
+        let frame = WebSocketFrameEntity(context: backgroundContext)
+        frame.createdAt = event.createdAt
+        frame.task = task
+        frame.direction = direction.rawValue
+        frame.frameType = event.frameType.rawValue
+        frame.payloadSize = Int64(event.data?.count ?? 0)
+
+        // Store payload if present
+        if let data = event.data, !data.isEmpty {
+            let contentType: NetworkLogger.ContentType? = event.frameType == .text ? "text/plain" : "application/octet-stream"
+            frame.payload = storeBlob(data, contentType: contentType)
+        }
+
+        task.webSocketFrames.insert(frame)
     }
 
     private func preprocessData(_ data: Data, contentType: NetworkLogger.ContentType?) -> Data {

--- a/Sources/Pulse/NetworkLogger/NetworkLogger+Redacting.swift
+++ b/Sources/Pulse/NetworkLogger/NetworkLogger+Redacting.swift
@@ -12,7 +12,8 @@ extension LoggerStore.Event {
             return self
         }
         switch self {
-        case .messageStored, .networkTaskProgressUpdated:
+        case .messageStored, .networkTaskProgressUpdated,
+             .webSocketTaskOpened, .webSocketTaskClosed, .webSocketFrameSent, .webSocketFrameReceived:
             return self
         case .networkTaskCreated(let event):
             var event = event
@@ -34,7 +35,8 @@ extension LoggerStore.Event {
             return self
         }
         switch self {
-        case .messageStored, .networkTaskProgressUpdated:
+        case .messageStored, .networkTaskProgressUpdated,
+             .webSocketTaskOpened, .webSocketTaskClosed, .webSocketFrameSent, .webSocketFrameReceived:
             return self
         case .networkTaskCreated(let event):
             var event = event
@@ -55,13 +57,26 @@ extension LoggerStore.Event {
             return self
         }
         switch self {
-        case .messageStored, .networkTaskProgressUpdated, .networkTaskCreated:
+        case .messageStored, .networkTaskProgressUpdated, .networkTaskCreated,
+             .webSocketTaskOpened, .webSocketTaskClosed:
             return self
         case .networkTaskCompleted(let event):
             var event = event
             event.requestBody = event.requestBody?.redactingSensitiveFields(excludedDataFields)
             event.responseBody = event.responseBody?.redactingSensitiveFields(excludedDataFields)
             return .networkTaskCompleted(event)
+        case .webSocketFrameSent(let frame):
+            var frame = frame
+            if frame.frameType == .text {
+                frame.data = frame.data?.redactingSensitiveFields(excludedDataFields)
+            }
+            return .webSocketFrameSent(frame)
+        case .webSocketFrameReceived(let frame):
+            var frame = frame
+            if frame.frameType == .text {
+                frame.data = frame.data?.redactingSensitiveFields(excludedDataFields)
+            }
+            return .webSocketFrameReceived(frame)
         }
     }
 }

--- a/Sources/Pulse/NetworkLogger/NetworkLogger.swift
+++ b/Sources/Pulse/NetworkLogger/NetworkLogger.swift
@@ -104,6 +104,16 @@ public final class NetworkLogger: @unchecked Sendable {
         /// is ignored completely.
         public var willHandleEvent: @Sendable (LoggerStore.Event) -> LoggerStore.Event? = { $0 }
 
+        // MARK: - WebSocket Configuration
+
+        /// If enabled, logs WebSocket frames (sent and received messages).
+        /// Defaults to `true`.
+        public var isWebSocketLoggingEnabled = true
+
+        /// Maximum size for WebSocket frame payloads. Larger frames will be truncated.
+        /// Defaults to 256 KB.
+        public var webSocketFrameSizeLimit: Int = 256_000
+
         /// Initializes the default configuration.
         public init() {}
     }
@@ -258,6 +268,132 @@ public final class NetworkLogger: @unchecked Sendable {
         )))
     }
 
+    // MARK: - WebSocket Logging
+
+    /// Logs when a WebSocket connection is opened.
+    public func logWebSocketOpened(_ task: URLSessionWebSocketTask, protocol: String?) {
+        guard configuration.isWebSocketLoggingEnabled else { return }
+
+        lock.lock()
+        let context = self.context(for: task)
+        lock.unlock()
+
+        send(.webSocketTaskOpened(.init(
+            taskId: context.taskId,
+            createdAt: Date(),
+            protocol: `protocol`
+        )))
+    }
+
+    /// Logs when a WebSocket connection is closed.
+    public func logWebSocketClosed(_ task: URLSessionWebSocketTask, closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
+        guard configuration.isWebSocketLoggingEnabled else { return }
+
+        lock.lock()
+        let context = self.context(for: task)
+        lock.unlock()
+
+        send(.webSocketTaskClosed(.init(
+            taskId: context.taskId,
+            createdAt: Date(),
+            closeCode: closeCode.rawValue,
+            reason: reason
+        )))
+    }
+
+    /// Logs a WebSocket frame that was sent.
+    public func logWebSocketFrameSent(_ task: URLSessionWebSocketTask, message: URLSessionWebSocketTask.Message) {
+        guard configuration.isWebSocketLoggingEnabled else { return }
+
+        lock.lock()
+        let context = self.context(for: task)
+        lock.unlock()
+
+        let frame = makeWebSocketFrame(taskId: context.taskId, message: message)
+        send(.webSocketFrameSent(frame))
+    }
+
+    /// Logs a WebSocket frame that was received.
+    public func logWebSocketFrameReceived(_ task: URLSessionWebSocketTask, message: URLSessionWebSocketTask.Message) {
+        guard configuration.isWebSocketLoggingEnabled else { return }
+
+        lock.lock()
+        let context = self.context(for: task)
+        lock.unlock()
+
+        let frame = makeWebSocketFrame(taskId: context.taskId, message: message)
+        send(.webSocketFrameReceived(frame))
+    }
+
+    /// Logs a ping sent on the WebSocket.
+    public func logWebSocketPingSent(_ task: URLSessionWebSocketTask) {
+        guard configuration.isWebSocketLoggingEnabled else { return }
+
+        lock.lock()
+        let context = self.context(for: task)
+        lock.unlock()
+
+        send(.webSocketFrameSent(.init(
+            taskId: context.taskId,
+            createdAt: Date(),
+            frameType: .ping,
+            data: nil,
+            isTruncated: false
+        )))
+    }
+
+    /// Logs a pong received on the WebSocket.
+    public func logWebSocketPongReceived(_ task: URLSessionWebSocketTask) {
+        guard configuration.isWebSocketLoggingEnabled else { return }
+
+        lock.lock()
+        let context = self.context(for: task)
+        lock.unlock()
+
+        send(.webSocketFrameReceived(.init(
+            taskId: context.taskId,
+            createdAt: Date(),
+            frameType: .pong,
+            data: nil,
+            isTruncated: false
+        )))
+    }
+
+    private func makeWebSocketFrame(taskId: UUID, message: URLSessionWebSocketTask.Message) -> LoggerStore.Event.WebSocketFrame {
+        let sizeLimit = configuration.webSocketFrameSizeLimit
+        switch message {
+        case .string(let text):
+            let data = Data(text.utf8)
+            let isTruncated = data.count > sizeLimit
+            let truncatedData = isTruncated ? data.prefix(sizeLimit) : data
+            return .init(
+                taskId: taskId,
+                createdAt: Date(),
+                frameType: .text,
+                data: Data(truncatedData),
+                isTruncated: isTruncated
+            )
+        case .data(let data):
+            let isTruncated = data.count > sizeLimit
+            let truncatedData = isTruncated ? data.prefix(sizeLimit) : data
+            return .init(
+                taskId: taskId,
+                createdAt: Date(),
+                frameType: .binary,
+                data: Data(truncatedData),
+                isTruncated: isTruncated
+            )
+        @unknown default:
+            return .init(
+                taskId: taskId,
+                createdAt: Date(),
+                frameType: .binary,
+                data: nil,
+                isTruncated: false
+            )
+        }
+    }
+
     private func send(_ event: LoggerStore.Event) {
         guard !isFilteringNeeded || filter(event) else {
             return
@@ -267,11 +403,27 @@ public final class NetworkLogger: @unchecked Sendable {
         }
         store.handle(event)
     }
+    
+    // MARK: - Public Event Logging
+    
+    /// Logs a raw event to the store. This is primarily used by third-party WebSocket
+    /// libraries (like Starscream) to log WebSocket events.
+    ///
+    /// - Parameter event: The event to log.
+    public func logEvent(_ event: LoggerStore.Event) {
+        send(event)
+    }
 
     /// Check if the events can be stored (included and not excluded).
     private func filter(_ event: LoggerStore.Event) -> Bool {
         guard let url = event.url else {
-            return false // Should never happen
+            // WebSocket frame events don't have a URL - they're tied to an already-filtered task
+            switch event {
+            case .webSocketTaskOpened, .webSocketTaskClosed, .webSocketFrameSent, .webSocketFrameReceived:
+                return true
+            default:
+                return false // Should never happen for other events
+            }
         }
         var host = url.host ?? ""
         if url.scheme == nil, let url = URL(string: "https://" + url.absoluteString) {

--- a/Sources/Pulse/Pulse.docc/Articles/NetworkLogging-Article.md
+++ b/Sources/Pulse/Pulse.docc/Articles/NetworkLogging-Article.md
@@ -172,6 +172,62 @@ private func process(event: LoggerStore.Event) {
 }
 ```
 
+## WebSocket Logging
+
+Pulse provides comprehensive WebSocket logging support for multiple frameworks.
+
+### URLSession WebSocket
+
+When using ``URLSessionProxy``, WebSocket tasks are automatically logged. Use the `webSocketTaskProxy` method to get full logging of sent and received messages:
+
+```swift
+let session = URLSessionProxy(configuration: .default)
+let wsTask = session.webSocketTaskProxy(with: URL(string: "wss://example.com/ws")!)
+wsTask.resume()
+
+// Send and receive messages - automatically logged
+try await wsTask.send(.string("Hello"))
+let message = try await wsTask.receive()
+```
+
+### Starscream
+
+Import the `PulseStarscream` module and enable logging with a single line:
+
+```swift
+import PulseStarscream
+import Starscream
+
+let socket = WebSocket(request: URLRequest(url: url))
+
+// Enable Pulse logging - optionally pass your own delegate to receive events
+let logger = socket.enablePulseLogging(delegate: myDelegate)
+
+socket.connect()
+
+// When sending messages manually, also log them
+socket.write(string: "Hello")
+logger.logSentText("Hello")
+```
+
+### Apollo GraphQL
+
+Import the `PulseApollo` module for GraphQL WebSocket subscription logging:
+
+```swift
+import PulseApollo
+import ApolloWebSocket
+
+let transport = WebSocketTransport(websocket: webSocket, store: store)
+
+// Enable Pulse logging
+let logger = transport.enablePulseLogging(delegate: self, url: websocketURL)
+
+// Log subscription events
+logger.logSubscriptionStarted("MySubscription")
+logger.logSubscriptionData("MySubscription", data: subscriptionData)
+```
+
 ## Network Debugging
 
 In addition to logging, Pulse provides network debugging features, such as logging. If you use the recommended ``URLSessionProxy``, these features are enabled automatically, and you don't need to do anything. In other cases, make sure to inject ``MockingURLProtocol`` in the set of URL protocols used by your `URLSession`:

--- a/Sources/Pulse/Pulse.docc/Pulse.md
+++ b/Sources/Pulse/Pulse.docc/Pulse.md
@@ -19,6 +19,14 @@ Logger and network inspector for Apple platforms.
 - ``URLSessionProxyDelegate``
 - ``MockingURLProtocol``
 
+### WebSocket Support
+
+Pulse provides comprehensive WebSocket logging support for multiple frameworks:
+
+- **URLSession**: Use ``URLSessionProxy`` and ``WebSocketTaskProxy`` for automatic logging
+- **Starscream**: Import `PulseStarscream` and use `WebSocket.enablePulseLogging()`
+- **Apollo GraphQL**: Import `PulseApollo` and use `WebSocketTransport.enablePulseLogging()`
+
 ### Remote Logging
 
 - ``RemoteLogger``

--- a/Sources/Pulse/RemoteLogger/RemoteLogger-Protocol.swift
+++ b/Sources/Pulse/RemoteLogger/RemoteLogger-Protocol.swift
@@ -20,6 +20,9 @@ extension RemoteLogger {
         case storeEventNetworkTaskCreated = 8
         case storeEventNetworkTaskProgressUpdated = 9
         case storeEventNetworkTaskCompleted = 10
+        // WebSocket events
+        case storeEventWebSocketTaskOpened = 11
+        case storeEventWebSocketTaskClosed = 12
         // A custom message with the following format:
         //
         // path (String)
@@ -27,6 +30,9 @@ extension RemoteLogger {
         //
         // Moving forward, all non-control packets will be send using this format.
         case message = 13
+        // WebSocket frames (sent via message format, but using dedicated codes for efficiency)
+        case storeEventWebSocketFrameSent = 14
+        case storeEventWebSocketFrameReceived = 15
     }
 
     package struct PacketClientHello: Codable {

--- a/Sources/Pulse/RemoteLogger/RemoteLogger.swift
+++ b/Sources/Pulse/RemoteLogger/RemoteLogger.swift
@@ -657,6 +657,14 @@ public final class RemoteLogger: ObservableObject, RemoteLoggerConnectionDelegat
             } catch {
                 os_log("Failed to encode network message %{public}@", log: log, type: .error, "\(error)")
             }
+        case .webSocketTaskOpened(let event):
+            connection?.send(code: .storeEventWebSocketTaskOpened, entity: event)
+        case .webSocketTaskClosed(let event):
+            connection?.send(code: .storeEventWebSocketTaskClosed, entity: event)
+        case .webSocketFrameSent(let frame):
+            connection?.send(code: .storeEventWebSocketFrameSent, entity: frame)
+        case .webSocketFrameReceived(let frame):
+            connection?.send(code: .storeEventWebSocketFrameReceived, entity: frame)
         }
     }
 

--- a/Sources/Pulse/URLSessionProxy/URLSessionProxy.swift
+++ b/Sources/Pulse/URLSessionProxy/URLSessionProxy.swift
@@ -108,6 +108,42 @@ public final class URLSessionProxy: URLSessionProtocol, @unchecked Sendable {
         session.webSocketTask(with: request)
     }
 
+    // MARK: - WebSocket Task Proxy
+
+    /// Creates a WebSocket task proxy that automatically logs sent and received frames.
+    ///
+    /// Use this instead of `webSocketTask(with:)` when you want automatic frame logging.
+    ///
+    /// - Parameter url: The WebSocket URL.
+    /// - Returns: A `WebSocketTaskProxy` that wraps the underlying task.
+    public func webSocketTaskProxy(with url: URL) -> WebSocketTaskProxy {
+        let task = session.webSocketTask(with: url)
+        logger.logTaskCreated(task)
+        return WebSocketTaskProxy(task: task, logger: logger)
+    }
+
+    /// Creates a WebSocket task proxy with subprotocols that automatically logs sent and received frames.
+    ///
+    /// - Parameters:
+    ///   - url: The WebSocket URL.
+    ///   - protocols: The subprotocols to request.
+    /// - Returns: A `WebSocketTaskProxy` that wraps the underlying task.
+    public func webSocketTaskProxy(with url: URL, protocols: [String]) -> WebSocketTaskProxy {
+        let task = session.webSocketTask(with: url, protocols: protocols)
+        logger.logTaskCreated(task)
+        return WebSocketTaskProxy(task: task, logger: logger)
+    }
+
+    /// Creates a WebSocket task proxy from a request that automatically logs sent and received frames.
+    ///
+    /// - Parameter request: The WebSocket request.
+    /// - Returns: A `WebSocketTaskProxy` that wraps the underlying task.
+    public func webSocketTaskProxy(with request: URLRequest) -> WebSocketTaskProxy {
+        let task = session.webSocketTask(with: request)
+        logger.logTaskCreated(task)
+        return WebSocketTaskProxy(task: task, logger: logger)
+    }
+
     // MARK: - URLSessionProtocol (Closures)
 
     public func dataTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, (any Error)?) -> Void) -> URLSessionDataTask {

--- a/Sources/Pulse/URLSessionProxy/URLSessionProxyDelegate.swift
+++ b/Sources/Pulse/URLSessionProxy/URLSessionProxyDelegate.swift
@@ -11,7 +11,7 @@ import Foundation
 /// method which allows the logger to start tracking network requests right
 /// after their creation. On earlier versions, you can (optionally) call
 /// ``NetworkLogger/logTaskCreated(_:)`` manually.
-public final class URLSessionProxyDelegate: NSObject, URLSessionTaskDelegate, URLSessionDataDelegate, URLSessionDownloadDelegate {
+public final class URLSessionProxyDelegate: NSObject, URLSessionTaskDelegate, URLSessionDataDelegate, URLSessionDownloadDelegate, URLSessionWebSocketDelegate {
     private let actualDelegate: URLSessionDelegate?
     private let taskDelegate: URLSessionTaskDelegate?
     private let interceptedSelectors: Set<Selector>
@@ -31,7 +31,10 @@ public final class URLSessionProxyDelegate: NSObject, URLSessionTaskDelegate, UR
             #selector(URLSessionTaskDelegate.urlSession(_:task:didFinishCollecting:)),
             #selector(URLSessionTaskDelegate.urlSession(_:task:didSendBodyData:totalBytesSent:totalBytesExpectedToSend:)),
             #selector(URLSessionDownloadDelegate.urlSession(_:downloadTask:didFinishDownloadingTo:)),
-            #selector(URLSessionDownloadDelegate.urlSession(_:downloadTask:didWriteData:totalBytesWritten:totalBytesExpectedToWrite:))
+            #selector(URLSessionDownloadDelegate.urlSession(_:downloadTask:didWriteData:totalBytesWritten:totalBytesExpectedToWrite:)),
+            // WebSocket delegate methods
+            #selector(URLSessionWebSocketDelegate.urlSession(_:webSocketTask:didOpenWithProtocol:)),
+            #selector(URLSessionWebSocketDelegate.urlSession(_:webSocketTask:didCloseWith:reason:))
         ]
         if #available(iOS 16, tvOS 16, macOS 13, watchOS 9, *) {
             interceptedSelectors.insert(#selector(URLSessionTaskDelegate.urlSession(_:didCreateTask:)))
@@ -84,6 +87,18 @@ public final class URLSessionProxyDelegate: NSObject, URLSessionTaskDelegate, UR
     public func urlSession(_ session: Foundation.URLSession, downloadTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) {
         logger.logTask(downloadTask, didUpdateProgress: (completed: totalBytesWritten, total: totalBytesExpectedToWrite))
         (actualDelegate as? URLSessionDownloadDelegate)?.urlSession?(session, downloadTask: downloadTask, didWriteData: bytesWritten, totalBytesWritten: totalBytesWritten, totalBytesExpectedToWrite: totalBytesExpectedToWrite)
+    }
+
+    // MARK: URLSessionWebSocketDelegate
+
+    public func urlSession(_ session: Foundation.URLSession, webSocketTask: URLSessionWebSocketTask, didOpenWithProtocol protocol: String?) {
+        logger.logWebSocketOpened(webSocketTask, protocol: `protocol`)
+        (actualDelegate as? URLSessionWebSocketDelegate)?.urlSession?(session, webSocketTask: webSocketTask, didOpenWithProtocol: `protocol`)
+    }
+
+    public func urlSession(_ session: Foundation.URLSession, webSocketTask: URLSessionWebSocketTask, didCloseWith closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
+        logger.logWebSocketClosed(webSocketTask, closeCode: closeCode, reason: reason)
+        (actualDelegate as? URLSessionWebSocketDelegate)?.urlSession?(session, webSocketTask: webSocketTask, didCloseWith: closeCode, reason: reason)
     }
 
     // MARK: Proxy

--- a/Sources/Pulse/URLSessionProxy/WebSocketTaskProxy.swift
+++ b/Sources/Pulse/URLSessionProxy/WebSocketTaskProxy.swift
@@ -1,0 +1,171 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020-2024 Alexander Grebenyuk (github.com/kean).
+
+import Foundation
+
+/// A wrapper around `URLSessionWebSocketTask` that intercepts WebSocket frames
+/// for logging purposes.
+///
+/// Since `URLSessionWebSocketTask` uses async methods for sending and receiving
+/// messages (rather than delegate callbacks), this wrapper intercepts those calls
+/// to log the frames.
+///
+/// ## Usage
+///
+/// Instead of using `URLSessionWebSocketTask` directly, use `WebSocketTaskProxy`:
+///
+/// ```swift
+/// let proxy = URLSessionProxy(configuration: .default)
+/// let wsProxy = proxy.webSocketTaskProxy(with: url)
+/// wsProxy.resume()
+///
+/// try await wsProxy.send(.string("Hello"))
+/// let message = try await wsProxy.receive()
+/// ```
+public final class WebSocketTaskProxy: @unchecked Sendable {
+    /// The underlying `URLSessionWebSocketTask`.
+    public let task: URLSessionWebSocketTask
+
+    private let logger: NetworkLogger
+
+    /// Creates a new WebSocket task proxy.
+    ///
+    /// - Parameters:
+    ///   - task: The underlying WebSocket task to wrap.
+    ///   - logger: The logger to use for logging frames. Defaults to the shared logger.
+    public init(task: URLSessionWebSocketTask, logger: NetworkLogger? = nil) {
+        self.task = task
+        self.logger = logger ?? .shared
+    }
+
+    // MARK: - Sending Messages
+
+    /// Sends a WebSocket message, logging it before transmission.
+    ///
+    /// - Parameter message: The message to send.
+    /// - Throws: An error if sending fails.
+    public func send(_ message: URLSessionWebSocketTask.Message) async throws {
+        logger.logWebSocketFrameSent(task, message: message)
+        try await task.send(message)
+    }
+
+    /// Sends a WebSocket message using a completion handler.
+    ///
+    /// - Parameters:
+    ///   - message: The message to send.
+    ///   - completionHandler: Called when the send completes.
+    public func send(_ message: URLSessionWebSocketTask.Message, completionHandler: @escaping @Sendable (Error?) -> Void) {
+        logger.logWebSocketFrameSent(task, message: message)
+        task.send(message, completionHandler: completionHandler)
+    }
+
+    // MARK: - Receiving Messages
+
+    /// Receives a WebSocket message, logging it after reception.
+    ///
+    /// - Returns: The received message.
+    /// - Throws: An error if receiving fails.
+    public func receive() async throws -> URLSessionWebSocketTask.Message {
+        let message = try await task.receive()
+        logger.logWebSocketFrameReceived(task, message: message)
+        return message
+    }
+
+    /// Receives a WebSocket message using a completion handler.
+    ///
+    /// - Parameter completionHandler: Called with the received message or error.
+    public func receive(completionHandler: @escaping @Sendable (Result<URLSessionWebSocketTask.Message, Error>) -> Void) {
+        task.receive { [logger, task] result in
+            if case .success(let message) = result {
+                logger.logWebSocketFrameReceived(task, message: message)
+            }
+            completionHandler(result)
+        }
+    }
+
+    // MARK: - Ping/Pong
+
+    /// Sends a ping and waits for a pong.
+    ///
+    /// - Parameter pongReceiveHandler: Called when pong is received or an error occurs.
+    public func sendPing(pongReceiveHandler: @escaping @Sendable (Error?) -> Void) {
+        logger.logWebSocketPingSent(task)
+        task.sendPing { [logger, task] error in
+            if error == nil {
+                logger.logWebSocketPongReceived(task)
+            }
+            pongReceiveHandler(error)
+        }
+    }
+
+    // MARK: - Task Control
+
+    /// Resumes the task.
+    public func resume() {
+        task.resume()
+    }
+
+    /// Suspends the task.
+    public func suspend() {
+        task.suspend()
+    }
+
+    /// Cancels the task.
+    public func cancel() {
+        task.cancel()
+    }
+
+    /// Cancels the task with a close code and optional reason.
+    ///
+    /// - Parameters:
+    ///   - closeCode: The WebSocket close code.
+    ///   - reason: Optional data explaining the reason for closing.
+    public func cancel(with closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
+        task.cancel(with: closeCode, reason: reason)
+    }
+
+    // MARK: - Task Properties
+
+    /// The close code received from the server, if any.
+    public var closeCode: URLSessionWebSocketTask.CloseCode {
+        task.closeCode
+    }
+
+    /// The close reason received from the server, if any.
+    public var closeReason: Data? {
+        task.closeReason
+    }
+
+    /// The current state of the task.
+    public var state: URLSessionTask.State {
+        task.state
+    }
+
+    /// The task identifier.
+    public var taskIdentifier: Int {
+        task.taskIdentifier
+    }
+
+    /// The original request used to create the task.
+    public var originalRequest: URLRequest? {
+        task.originalRequest
+    }
+
+    /// The current request (may differ from original after redirects).
+    public var currentRequest: URLRequest? {
+        task.currentRequest
+    }
+
+    /// The response received from the server.
+    public var response: URLResponse? {
+        task.response
+    }
+
+    /// The maximum message size that can be received.
+    public var maximumMessageSize: Int {
+        get { task.maximumMessageSize }
+        set { task.maximumMessageSize = newValue }
+    }
+}
+

--- a/Sources/PulseApollo/ApolloWebSocketLogger.swift
+++ b/Sources/PulseApollo/ApolloWebSocketLogger.swift
@@ -1,0 +1,305 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020-2024 Alexander Grebenyuk (github.com/kean).
+
+import Foundation
+import Pulse
+import ApolloWebSocket
+import Apollo
+import ApolloAPI
+
+/// A delegate proxy that intercepts Apollo WebSocket events and logs them to Pulse.
+///
+/// Usage:
+/// ```swift
+/// let transport = WebSocketTransport(websocket: webSocket, store: apolloStore)
+/// let logger = ApolloWebSocketLogger(transport: transport, delegate: self, url: wsURL)
+/// transport.delegate = logger
+/// ```
+///
+/// The logger will forward all delegate calls to your original delegate while logging
+/// WebSocket connection events and GraphQL subscription messages to Pulse.
+public final class ApolloWebSocketLogger: WebSocketTransportDelegate, @unchecked Sendable {
+    private let logger: NetworkLogger
+    nonisolated(unsafe) private weak var delegate: WebSocketTransportDelegate?
+    private let taskId: UUID
+    private let url: URL
+    private let createdAt: Date
+    nonisolated(unsafe) private var hasLoggedTaskCreation = false
+    
+    /// The underlying Apollo WebSocketTransport being logged.
+    nonisolated(unsafe) public private(set) weak var transport: WebSocketTransport?
+    
+    /// Creates a new ApolloWebSocketLogger.
+    /// - Parameters:
+    ///   - transport: The Apollo WebSocketTransport to log.
+    ///   - delegate: Your original delegate that will receive forwarded events.
+    ///   - url: The WebSocket URL (for display in Pulse).
+    ///   - logger: The NetworkLogger to use. Defaults to `.shared`.
+    public init(
+        transport: WebSocketTransport,
+        delegate: WebSocketTransportDelegate? = nil,
+        url: URL,
+        logger: NetworkLogger = .shared
+    ) {
+        self.transport = transport
+        self.delegate = delegate
+        self.url = url
+        self.logger = logger
+        self.taskId = UUID()
+        self.createdAt = Date()
+    }
+    
+    // MARK: - WebSocketTransportDelegate
+    
+    public func webSocketTransportDidConnect(_ webSocketTransport: WebSocketTransport) {
+        logTaskCreated()
+        logTaskOpened()
+        delegate?.webSocketTransportDidConnect(webSocketTransport)
+    }
+    
+    public func webSocketTransportDidReconnect(_ webSocketTransport: WebSocketTransport) {
+        // Log as a new connection after reconnect
+        logFrame(.text, data: Data("{\"type\":\"reconnected\"}".utf8), isSent: false)
+        delegate?.webSocketTransportDidReconnect(webSocketTransport)
+    }
+    
+    public func webSocketTransport(_ webSocketTransport: WebSocketTransport, didDisconnectWithError error: (any Error)?) {
+        if let error = error {
+            logTaskClosed(reason: error.localizedDescription, code: 1006)
+        } else {
+            logTaskClosed(reason: "Disconnected", code: 1000)
+        }
+        delegate?.webSocketTransport(webSocketTransport, didDisconnectWithError: error)
+    }
+    
+    // MARK: - Manual Logging for GraphQL Messages
+    
+    /// Log a GraphQL subscription message that was sent.
+    /// Call this when sending a subscription or other WebSocket message.
+    ///
+    /// - Parameter message: The GraphQL message payload (typically JSON).
+    public func logSentMessage(_ message: String) {
+        logTaskCreatedIfNeeded()
+        logFrame(.text, data: Data(message.utf8), isSent: true)
+    }
+    
+    /// Log a GraphQL subscription message that was sent.
+    /// - Parameter data: The raw message data.
+    public func logSentData(_ data: Data) {
+        logTaskCreatedIfNeeded()
+        logFrame(.binary, data: data, isSent: true)
+    }
+    
+    /// Log a GraphQL subscription message that was received.
+    /// - Parameter message: The GraphQL message payload (typically JSON).
+    public func logReceivedMessage(_ message: String) {
+        logTaskCreatedIfNeeded()
+        logFrame(.text, data: Data(message.utf8), isSent: false)
+    }
+    
+    /// Log a GraphQL subscription message that was received.
+    /// - Parameter data: The raw message data.
+    public func logReceivedData(_ data: Data) {
+        logTaskCreatedIfNeeded()
+        logFrame(.binary, data: data, isSent: false)
+    }
+    
+    /// Log a GraphQL subscription result as a received message.
+    /// - Parameter result: Any Encodable result from a GraphQL subscription.
+    public func logReceivedResult<T: Encodable>(_ result: T) {
+        logTaskCreatedIfNeeded()
+        if let data = try? JSONEncoder().encode(result) {
+            logFrame(.text, data: data, isSent: false)
+        }
+    }
+    
+    /// Log a GraphQL subscription being started.
+    /// - Parameter operationName: The name of the GraphQL subscription operation.
+    public func logSubscriptionStarted(_ operationName: String) {
+        logTaskCreatedIfNeeded()
+        let message = """
+        {"type":"subscribe","payload":{"operationName":"\(operationName)"}}
+        """
+        logFrame(.text, data: Data(message.utf8), isSent: true)
+    }
+    
+    // MARK: - Apollo SelectionSet Logging
+    
+    /// Log a GraphQL subscription result (success) with the actual payload data.
+    /// This method handles Apollo's SelectionSet types and converts them to readable JSON.
+    ///
+    /// - Parameters:
+    ///   - operationName: The name of the GraphQL operation.
+    ///   - data: The Apollo SelectionSet data from the subscription result.
+    public func logSubscriptionData<T: SelectionSet>(_ operationName: String, data: T) {
+        logTaskCreatedIfNeeded()
+        
+        // Convert Apollo's internal data to JSON-safe format
+        let jsonSafeData = Self.convertToJSONSafe(data.__data._data)
+        
+        if let jsonData = try? JSONSerialization.data(withJSONObject: jsonSafeData, options: [.prettyPrinted, .sortedKeys]),
+           let jsonString = String(data: jsonData, encoding: .utf8) {
+            let message = "{\"type\":\"next\",\"operation\":\"\(operationName)\",\"data\":\(jsonString)}"
+            logFrame(.text, data: Data(message.utf8), isSent: false)
+        } else {
+            // Fallback to string description
+            let description = String(describing: data).prefix(2000)
+            let escapedDescription = description.replacingOccurrences(of: "\"", with: "\\\"")
+            let message = "{\"type\":\"next\",\"operation\":\"\(operationName)\",\"data\":\"\(escapedDescription)\"}"
+            logFrame(.text, data: Data(message.utf8), isSent: false)
+        }
+    }
+    
+    /// Log a GraphQL subscription error.
+    ///
+    /// - Parameters:
+    ///   - operationName: The name of the GraphQL operation.
+    ///   - error: The error that occurred.
+    public func logSubscriptionError(_ operationName: String, error: Error) {
+        logTaskCreatedIfNeeded()
+        let escapedError = error.localizedDescription.replacingOccurrences(of: "\"", with: "\\\"")
+        let message = "{\"type\":\"error\",\"operation\":\"\(operationName)\",\"error\":\"\(escapedError)\"}"
+        logFrame(.text, data: Data(message.utf8), isSent: false)
+    }
+    
+    // MARK: - JSON Conversion Helpers
+    
+    /// Recursively converts Apollo's data dictionary to JSON-serializable types.
+    /// Handles Apollo's DataDict and other internal types by extracting their underlying data.
+    private static func convertToJSONSafe(_ value: Any) -> Any {
+        // Handle Apollo's DataDict by extracting its internal data
+        if let dataDict = value as? DataDict {
+            return convertToJSONSafe(dataDict._data)
+        }
+        
+        // Handle dictionaries
+        if let dict = value as? [String: Any] {
+            return dict.mapValues { convertToJSONSafe($0) }
+        }
+        
+        // Handle arrays
+        if let array = value as? [Any] {
+            return array.map { convertToJSONSafe($0) }
+        }
+        
+        // Handle primitive types
+        if let string = value as? String {
+            return string
+        }
+        if let number = value as? NSNumber {
+            return number
+        }
+        if let bool = value as? Bool {
+            return bool
+        }
+        if value is NSNull {
+            return NSNull()
+        }
+        
+        // Handle Optional by unwrapping
+        let mirror = Mirror(reflecting: value)
+        if mirror.displayStyle == .optional {
+            if let child = mirror.children.first {
+                return convertToJSONSafe(child.value)
+            } else {
+                return NSNull()
+            }
+        }
+        
+        // Handle SelectionSet types by extracting their __data
+        if let selectionSet = value as? (any SelectionSet) {
+            return convertToJSONSafe(selectionSet.__data._data)
+        }
+        
+        // Last resort: convert to string representation
+        return String(describing: value)
+    }
+    
+    // MARK: - Logging Helpers
+    
+    private func logTaskCreatedIfNeeded() {
+        if !hasLoggedTaskCreation {
+            logTaskCreated()
+            logTaskOpened()
+        }
+    }
+    
+    private func logTaskCreated() {
+        guard !hasLoggedTaskCreation else { return }
+        hasLoggedTaskCreation = true
+        
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        
+        logger.logEvent(.networkTaskCreated(.init(
+            taskId: taskId,
+            taskType: .webSocketTask,
+            createdAt: createdAt,
+            originalRequest: NetworkLogger.Request(request),
+            currentRequest: nil,
+            label: "Apollo GraphQL",
+            taskDescription: "Apollo WebSocket Subscription"
+        )))
+    }
+    
+    private func logTaskOpened() {
+        logger.logEvent(.webSocketTaskOpened(.init(
+            taskId: taskId,
+            createdAt: Date(),
+            protocol: "graphql-transport-ws"
+        )))
+    }
+    
+    private func logFrame(_ type: LoggerStore.Event.WebSocketFrame.FrameType, data: Data, isSent: Bool) {
+        let frame = LoggerStore.Event.WebSocketFrame(
+            taskId: taskId,
+            createdAt: Date(),
+            frameType: type,
+            data: data,
+            isTruncated: false
+        )
+        
+        if isSent {
+            logger.logEvent(.webSocketFrameSent(frame))
+        } else {
+            logger.logEvent(.webSocketFrameReceived(frame))
+        }
+    }
+    
+    private func logTaskClosed(reason: String, code: UInt16) {
+        logger.logEvent(.webSocketTaskClosed(.init(
+            taskId: taskId,
+            createdAt: Date(),
+            closeCode: Int(code),
+            reason: Data(reason.utf8)
+        )))
+    }
+}
+
+// MARK: - WebSocketTransport Extension for Easy Integration
+
+public extension WebSocketTransport {
+    /// Creates an ApolloWebSocketLogger and sets it as the delegate.
+    /// - Parameters:
+    ///   - delegate: Your original delegate that will receive forwarded events.
+    ///   - url: The WebSocket URL (for display in Pulse).
+    ///   - logger: The NetworkLogger to use. Defaults to `.shared`.
+    /// - Returns: The ApolloWebSocketLogger instance (retain this to keep logging active).
+    @discardableResult
+    func enablePulseLogging(
+        delegate: WebSocketTransportDelegate? = nil,
+        url: URL,
+        logger: NetworkLogger = .shared
+    ) -> ApolloWebSocketLogger {
+        let apolloLogger = ApolloWebSocketLogger(
+            transport: self,
+            delegate: delegate,
+            url: url,
+            logger: logger
+        )
+        self.delegate = apolloLogger
+        return apolloLogger
+    }
+}
+

--- a/Sources/PulseStarscream/StarscreamLogger.swift
+++ b/Sources/PulseStarscream/StarscreamLogger.swift
@@ -1,0 +1,180 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020-2024 Alexander Grebenyuk (github.com/kean).
+
+import Foundation
+import Pulse
+import Starscream
+
+/// A delegate proxy that intercepts Starscream WebSocket events and logs them to Pulse.
+///
+/// Usage:
+/// ```swift
+/// let socket = WebSocket(request: request)
+/// let logger = StarscreamLogger(socket: socket, delegate: self)
+/// socket.delegate = logger
+/// socket.connect()
+/// ```
+///
+/// The logger will forward all delegate calls to your original delegate while logging
+/// WebSocket frames to Pulse.
+public final class StarscreamLogger: WebSocketDelegate {
+    private let logger: NetworkLogger
+    private weak var delegate: WebSocketDelegate?
+    private let taskId: UUID
+    private let originalRequest: URLRequest
+    private let createdAt: Date
+    private var hasLoggedTaskCreation = false
+    
+    /// The underlying Starscream WebSocket being logged.
+    public private(set) weak var socket: WebSocket?
+    
+    /// Creates a new StarscreamLogger.
+    /// - Parameters:
+    ///   - socket: The Starscream WebSocket to log.
+    ///   - delegate: Your original delegate that will receive forwarded events.
+    ///   - logger: The NetworkLogger to use. Defaults to `.shared`.
+    public init(socket: WebSocket, delegate: WebSocketDelegate? = nil, logger: NetworkLogger = .shared) {
+        self.socket = socket
+        self.delegate = delegate
+        self.logger = logger
+        self.taskId = UUID()
+        self.originalRequest = socket.request
+        self.createdAt = Date()
+    }
+    
+    // MARK: - WebSocketDelegate
+    
+    public func didReceive(event: Starscream.WebSocketEvent, client: any Starscream.WebSocketClient) {
+        switch event {
+        case .connected(let headers):
+            logTaskCreated()
+            logTaskOpened(headers: headers)
+            
+        case .disconnected(let reason, let code):
+            logTaskClosed(reason: reason, code: code)
+            
+        case .text(let string):
+            logFrame(.text, data: Data(string.utf8), isSent: false)
+            
+        case .binary(let data):
+            logFrame(.binary, data: data, isSent: false)
+            
+        case .ping(let data):
+            logFrame(.ping, data: data ?? Data(), isSent: false)
+            
+        case .pong(let data):
+            logFrame(.pong, data: data ?? Data(), isSent: false)
+            
+        case .viabilityChanged, .reconnectSuggested:
+            break // Not logged
+            
+        case .cancelled:
+            logTaskClosed(reason: "Cancelled", code: 1000)
+            
+        case .error(let error):
+            logError(error)
+            
+        case .peerClosed:
+            logTaskClosed(reason: "Peer closed", code: 1000)
+        }
+        
+        // Forward to original delegate
+        delegate?.didReceive(event: event, client: client)
+    }
+    
+    // MARK: - Logging Helpers
+    
+    private func logTaskCreated() {
+        guard !hasLoggedTaskCreation else { return }
+        hasLoggedTaskCreation = true
+        
+        logger.logEvent(.networkTaskCreated(.init(
+            taskId: taskId,
+            taskType: .webSocketTask,
+            createdAt: createdAt,
+            originalRequest: NetworkLogger.Request(originalRequest),
+            currentRequest: nil,
+            label: "Starscream",
+            taskDescription: "Starscream WebSocket"
+        )))
+    }
+    
+    private func logTaskOpened(headers: [String: String]) {
+        // Extract the WebSocket protocol from headers if available
+        let wsProtocol = headers["Sec-WebSocket-Protocol"]
+        
+        logger.logEvent(.webSocketTaskOpened(.init(
+            taskId: taskId,
+            createdAt: Date(),
+            protocol: wsProtocol
+        )))
+    }
+    
+    private func logFrame(_ type: LoggerStore.Event.WebSocketFrame.FrameType, data: Data, isSent: Bool) {
+        let frame = LoggerStore.Event.WebSocketFrame(
+            taskId: taskId,
+            createdAt: Date(),
+            frameType: type,
+            data: data,
+            isTruncated: false
+        )
+        
+        if isSent {
+            logger.logEvent(.webSocketFrameSent(frame))
+        } else {
+            logger.logEvent(.webSocketFrameReceived(frame))
+        }
+    }
+    
+    private func logTaskClosed(reason: String, code: UInt16) {
+        logger.logEvent(.webSocketTaskClosed(.init(
+            taskId: taskId,
+            createdAt: Date(),
+            closeCode: Int(code),
+            reason: Data(reason.utf8)
+        )))
+    }
+    
+    private func logError(_ error: Error?) {
+        // Log as a close event with error information
+        let reason = error?.localizedDescription ?? "Unknown error"
+        logTaskClosed(reason: reason, code: 1006) // 1006 = Abnormal Closure
+    }
+    
+    // MARK: - Manual Logging for Sent Messages
+    
+    /// Call this method after sending a text message to log it.
+    /// - Parameter text: The text message that was sent.
+    public func logSentText(_ text: String) {
+        logFrame(.text, data: Data(text.utf8), isSent: true)
+    }
+    
+    /// Call this method after sending binary data to log it.
+    /// - Parameter data: The binary data that was sent.
+    public func logSentData(_ data: Data) {
+        logFrame(.binary, data: data, isSent: true)
+    }
+    
+    /// Call this method after sending a ping to log it.
+    /// - Parameter data: The ping data that was sent.
+    public func logSentPing(_ data: Data = Data()) {
+        logFrame(.ping, data: data, isSent: true)
+    }
+}
+
+// MARK: - WebSocket Extension for Easy Integration
+
+public extension WebSocket {
+    /// Creates a StarscreamLogger and sets it as the delegate.
+    /// - Parameters:
+    ///   - delegate: Your original delegate that will receive forwarded events.
+    ///   - logger: The NetworkLogger to use. Defaults to `.shared`.
+    /// - Returns: The StarscreamLogger instance (retain this to keep logging active).
+    @discardableResult
+    func enablePulseLogging(delegate: WebSocketDelegate? = nil, logger: NetworkLogger = .shared) -> StarscreamLogger {
+        let starscreamLogger = StarscreamLogger(socket: self, delegate: delegate, logger: logger)
+        self.delegate = starscreamLogger
+        return starscreamLogger
+    }
+}

--- a/Sources/PulseUI/Features/Console/Views/ConsoleHelperViews.swift
+++ b/Sources/PulseUI/Features/Console/Views/ConsoleHelperViews.swift
@@ -33,6 +33,17 @@ struct MockBadgeView: View {
     }
 }
 
+struct WebSocketBadgeView: View {
+    var body: some View {
+        Text("WS")
+            .foregroundStyle(.white)
+            .font(.caption2.weight(.semibold))
+            .padding(EdgeInsets(top: 2, leading: 5, bottom: 1, trailing: 5))
+            .background(Color.blue.opacity(0.75))
+            .clipShape(Capsule())
+    }
+}
+
 struct StatusIndicatorView: View {
     let state: NetworkTaskEntity.State?
 

--- a/Sources/PulseUI/Features/Console/Views/ConsoleTaskCell.swift
+++ b/Sources/PulseUI/Features/Console/Views/ConsoleTaskCell.swift
@@ -54,6 +54,9 @@ package struct ConsoleTaskCell: View {
             if task.isMocked {
                 MockBadgeView()
             }
+            if task.isWebSocket {
+                WebSocketBadgeView()
+            }
             info.highlighted(highlightedArea == .header)
 
             Spacer()

--- a/Sources/PulseUI/Features/Filters/Filters/ConsoleFilters.swift
+++ b/Sources/PulseUI/Features/Filters/Filters/ConsoleFilters.swift
@@ -24,6 +24,7 @@ struct ConsoleFilters: Hashable {
     struct Network: Hashable {
         var host = Host()
         var url = URL()
+        var taskTypes = TaskTypes()
     }
 }
 
@@ -67,5 +68,10 @@ extension ConsoleFilters {
     struct URL: ConsoleFilterProtocol {
         var hidden: Set<String> = []
         var focused: String?
+    }
+
+    struct TaskTypes: ConsoleFilterProtocol {
+        /// The set of enabled task types. By default, all types are included.
+        var types: Set<NetworkLogger.TaskType> = Set(NetworkLogger.TaskType.allCases)
     }
 }

--- a/Sources/PulseUI/Features/Filters/Filters/ConsoleSearchCriteria+Predicates.swift
+++ b/Sources/PulseUI/Features/Filters/Filters/ConsoleSearchCriteria+Predicates.swift
@@ -82,5 +82,10 @@ private func makePredicates(for criteria: ConsoleFilters.Network) -> [NSPredicat
         predicates.append(NSPredicate(format: "NOT url IN %@", Array(criteria.url.hidden)))
     }
 
+    // Task type filter
+    if criteria.taskTypes.types.count != NetworkLogger.TaskType.allCases.count {
+        predicates.append(NSPredicate(format: "taskType IN %@", Array(criteria.taskTypes.types.map { $0.rawValue })))
+    }
+
     return predicates
 }

--- a/Sources/PulseUI/Features/Inspector/NetworkInspectorView-shared.swift
+++ b/Sources/PulseUI/Features/Inspector/NetworkInspectorView-shared.swift
@@ -31,6 +31,22 @@ extension NetworkInspectorView {
     }
 
     @ViewBuilder
+    static func makeWebSocketSection(task: NetworkTaskEntity) -> some View {
+        if task.isWebSocket {
+            NavigationLink(destination: WebSocketInspectorView(task: task)) {
+                HStack {
+                    Image(systemName: "arrow.up.arrow.down.circle")
+                        .foregroundColor(.blue)
+                    Text("WebSocket Frames")
+                    Spacer()
+                    Text("\(task.webSocketFrames.count)")
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
     static func makeHeaderView(task: NetworkTaskEntity, store: LoggerStore) -> some View {
         ZStack {
             NetworkInspectorTransferInfoView(viewModel: .init(empty: true))

--- a/Sources/PulseUI/Features/Inspector/NetworkInspectorView.swift
+++ b/Sources/PulseUI/Features/Inspector/NetworkInspectorView.swift
@@ -55,6 +55,11 @@ package struct NetworkInspectorView: View {
             Section {
                 NetworkInspectorView.makeResponseSection(task: task)
             }
+            if task.isWebSocket {
+                Section {
+                    NetworkInspectorView.makeWebSocketSection(task: task)
+                }
+            }
             Section {
                 NetworkMetricsCell(task: task)
                 NetworkCURLCell(task: task)

--- a/Sources/PulseUI/Features/Inspector/WebSocketInspectorView.swift
+++ b/Sources/PulseUI/Features/Inspector/WebSocketInspectorView.swift
@@ -1,0 +1,290 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020-2024 Alexander Grebenyuk (github.com/kean).
+
+#if os(iOS) || os(visionOS) || os(macOS)
+
+import SwiftUI
+import CoreData
+import Pulse
+
+/// Displays a timeline of WebSocket frames for a given network task.
+@available(iOS 16, visionOS 1, macOS 13, *)
+public struct WebSocketInspectorView: View {
+    @ObservedObject var task: NetworkTaskEntity
+    @Environment(\.store) private var store
+
+    public init(task: NetworkTaskEntity) {
+        self.task = task
+    }
+
+    public var body: some View {
+        List {
+            if task.webSocketFrames.isEmpty {
+                Section {
+                    Text("No frames recorded")
+                        .foregroundColor(.secondary)
+                        .font(.subheadline)
+                }
+            } else {
+                Section {
+                    connectionInfoView
+                }
+                Section("Frames (\(task.webSocketFrames.count))") {
+                    ForEach(task.orderedWebSocketFrames) { frame in
+                        WebSocketFrameRow(frame: frame)
+                    }
+                }
+            }
+        }
+        #if os(iOS) || os(visionOS)
+        .listStyle(.insetGrouped)
+        #endif
+        .navigationTitle("WebSocket Frames")
+        #if os(iOS) || os(visionOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+    }
+
+    @ViewBuilder
+    private var connectionInfoView: some View {
+        if let wsProtocol = task.webSocketProtocol {
+            HStack {
+                Text("Protocol")
+                Spacer()
+                Text(wsProtocol)
+                    .foregroundColor(.secondary)
+            }
+        }
+        if task.webSocketCloseCode != 0 {
+            HStack {
+                Text("Close Code")
+                Spacer()
+                Text(closeCodeDescription(for: task.webSocketCloseCode))
+                    .foregroundColor(.secondary)
+            }
+        }
+        if let reason = task.webSocketCloseReason, !reason.isEmpty {
+            HStack {
+                Text("Close Reason")
+                Spacer()
+                Text(String(data: reason, encoding: .utf8) ?? "Binary data")
+                    .foregroundColor(.secondary)
+                    .lineLimit(2)
+            }
+        }
+        HStack {
+            Text("Total Frames")
+            Spacer()
+            Text("\(task.webSocketFrames.count)")
+                .foregroundColor(.secondary)
+        }
+        HStack {
+            Text("Sent")
+            Spacer()
+            Text("\(sentFramesCount)")
+                .foregroundColor(.secondary)
+        }
+        HStack {
+            Text("Received")
+            Spacer()
+            Text("\(receivedFramesCount)")
+                .foregroundColor(.secondary)
+        }
+    }
+
+    private var sentFramesCount: Int {
+        task.webSocketFrames.filter { $0.frameDirection == .sent }.count
+    }
+
+    private var receivedFramesCount: Int {
+        task.webSocketFrames.filter { $0.frameDirection == .received }.count
+    }
+
+    private func closeCodeDescription(for code: Int16) -> String {
+        switch code {
+        case 1000: return "1000 (Normal)"
+        case 1001: return "1001 (Going Away)"
+        case 1002: return "1002 (Protocol Error)"
+        case 1003: return "1003 (Unsupported Data)"
+        case 1005: return "1005 (No Status)"
+        case 1006: return "1006 (Abnormal)"
+        case 1007: return "1007 (Invalid Data)"
+        case 1008: return "1008 (Policy Violation)"
+        case 1009: return "1009 (Message Too Big)"
+        case 1010: return "1010 (Extension Required)"
+        case 1011: return "1011 (Internal Error)"
+        case 1015: return "1015 (TLS Handshake)"
+        default: return "\(code)"
+        }
+    }
+}
+
+/// A row displaying a single WebSocket frame.
+@available(iOS 16, visionOS 1, macOS 13, *)
+struct WebSocketFrameRow: View {
+    let frame: WebSocketFrameEntity
+
+    var body: some View {
+        NavigationLink(destination: WebSocketFrameDetailView(frame: frame)) {
+            HStack(spacing: 12) {
+                directionIcon
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack {
+                        Text(frameTypeLabel)
+                            .font(.subheadline.weight(.medium))
+                        Spacer()
+                        Text(formattedDate)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    HStack {
+                        Text(sizeLabel)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                        if let preview = payloadPreview {
+                            Text(preview)
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                                .lineLimit(1)
+                        }
+                    }
+                }
+            }
+            .padding(.vertical, 4)
+        }
+    }
+
+    @ViewBuilder
+    private var directionIcon: some View {
+        Image(systemName: frame.frameDirection == .sent ? "arrow.up.circle.fill" : "arrow.down.circle.fill")
+            .foregroundColor(frame.frameDirection == .sent ? .blue : .green)
+            .font(.title2)
+    }
+
+    private var frameTypeLabel: String {
+        switch frame.type {
+        case .text: return "Text"
+        case .binary: return "Binary"
+        case .ping: return "Ping"
+        case .pong: return "Pong"
+        }
+    }
+
+    private var sizeLabel: String {
+        ByteCountFormatter.string(fromByteCount: frame.payloadSize, countStyle: .file)
+    }
+
+    private var formattedDate: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm:ss.SSS"
+        return formatter.string(from: frame.createdAt)
+    }
+
+    private var payloadPreview: String? {
+        guard frame.type == .text, let data = frame.payload?.data else {
+            return nil
+        }
+        let text = String(data: data, encoding: .utf8) ?? ""
+        let trimmed = text.prefix(50)
+        if trimmed.count < text.count {
+            return String(trimmed) + "..."
+        }
+        return String(trimmed)
+    }
+}
+
+/// Detailed view of a single WebSocket frame.
+@available(iOS 16, visionOS 1, macOS 13, *)
+struct WebSocketFrameDetailView: View {
+    let frame: WebSocketFrameEntity
+    @State private var shareItems: ShareItems?
+
+    var body: some View {
+        List {
+            Section("Frame Info") {
+                HStack {
+                    Text("Direction")
+                    Spacer()
+                    Text(frame.frameDirection == .sent ? "Sent" : "Received")
+                        .foregroundColor(.secondary)
+                }
+                HStack {
+                    Text("Type")
+                    Spacer()
+                    Text(frameTypeLabel)
+                        .foregroundColor(.secondary)
+                }
+                HStack {
+                    Text("Size")
+                    Spacer()
+                    Text(ByteCountFormatter.string(fromByteCount: frame.payloadSize, countStyle: .file))
+                        .foregroundColor(.secondary)
+                }
+                HStack {
+                    Text("Timestamp")
+                    Spacer()
+                    Text(formattedDate)
+                        .foregroundColor(.secondary)
+                }
+            }
+
+            if let data = frame.payload?.data, !data.isEmpty {
+                Section("Payload") {
+                    if frame.type == .text {
+                        let text = String(data: data, encoding: .utf8) ?? "Unable to decode as UTF-8"
+                        Text(text)
+                            .font(.system(.body, design: .monospaced))
+                            .textSelection(.enabled)
+                    } else {
+                        Text("Binary data (\(data.count) bytes)")
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+        }
+        #if os(iOS) || os(visionOS)
+        .listStyle(.insetGrouped)
+        #endif
+        .navigationTitle(frameTypeLabel + " Frame")
+        #if os(iOS) || os(visionOS)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .automatic) {
+                if let data = frame.payload?.data {
+                    Button(action: { sharePayload(data) }) {
+                        Image(systemName: "square.and.arrow.up")
+                    }
+                }
+            }
+        }
+        .sheet(item: $shareItems, content: ShareView.init)
+        #endif
+    }
+
+    private var frameTypeLabel: String {
+        switch frame.type {
+        case .text: return "Text"
+        case .binary: return "Binary"
+        case .ping: return "Ping"
+        case .pong: return "Pong"
+        }
+    }
+
+    private var formattedDate: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd HH:mm:ss.SSS"
+        return formatter.string(from: frame.createdAt)
+    }
+
+    private func sharePayload(_ data: Data) {
+        if frame.type == .text, let text = String(data: data, encoding: .utf8) {
+            shareItems = ShareItems([text])
+        } else {
+            shareItems = ShareItems([data])
+        }
+    }
+}
+
+#endif
+


### PR DESCRIPTION
## Summary

This PR adds comprehensive WebSocket logging support to Pulse, enabling developers to inspect WebSocket traffic alongside regular HTTP requests.

## Features

### URLSession WebSocket Support
- Extended `URLSessionProxyDelegate` with `URLSessionWebSocketDelegate` conformance
- Added `WebSocketTaskProxy` to intercept `send` and `receive` operations
- Updated `URLSessionProxy` with `webSocketTaskProxy(with:)` method for full logging

### New WebSocket Event Types
- `webSocketTaskOpened`: Logs when a WebSocket connection is established
- `webSocketTaskClosed`: Logs connection closure with code and reason
- `webSocketFrameSent`: Logs outgoing frames (text/binary)
- `webSocketFrameReceived`: Logs incoming frames (text/binary)

### Core Data Model Extensions
- Added `WebSocketFrameEntity` for persistent storage of frames
- Added `webSocketFrames` relationship to `NetworkTaskEntity`
- Frame entities track type, data, direction, and timestamps

### PulseStarscream Integration (new library target)
- `StarscreamLogger`: `WebSocketDelegate` proxy for logging
- Convenience extension: `WebSocket.enablePulseLogging()`
- Logs connection lifecycle and frame data

### PulseApollo Integration (new library target)
- `ApolloWebSocketLogger`: `WebSocketTransportDelegate` proxy
- Supports GraphQL subscription logging with JSON serialization
- Handles Apollo's internal `DataDict`/`SelectionSet` types
- Convenience extension: `WebSocketTransport.enablePulseLogging()`

### UI Enhancements
- `WebSocketInspectorView`: Timeline of frames with expandable details
- WebSocket badge (WS) in console task cells
- Task type filtering for WebSocket connections
- JSON formatting for text frames

### Demo App
- Added `WebSocketDemoView` with three test scenarios:
  - URLSession WebSocket (echo.websocket.org)
  - Starscream WebSocket (echo.websocket.org)
  - Apollo WebSocket (simulated GraphQL subscription)
- Tab-based UI with embedded Pulse console

### Documentation
- Updated DocC documentation with WebSocket usage examples
- Added WebSocket section to Network Logging article

## Usage Examples

### URLSession
```swift
let session = URLSessionProxy(configuration: .default)
let wsTask = session.webSocketTaskProxy(with: url)
wsTask.resume()

try await wsTask.send(.string("Hello"))
let message = try await wsTask.receive()
```

### Starscream
```swift
import PulseStarscream

let socket = WebSocket(request: request)
socket.enablePulseLogging(delegate: myDelegate)
socket.connect()
```

### Apollo GraphQL
```swift
import PulseApollo

let transport = WebSocketTransport(websocket: ws, store: store)
transport.enablePulseLogging(delegate: self, url: url)
```

## Testing
- Builds successfully with `swift build`
- Demo app builds and runs on iOS Simulator
- Manual testing with echo.websocket.org

## Breaking Changes
None - all changes are additive.

## Dependencies Added
- Starscream 4.0+ (for PulseStarscream target)
- Apollo iOS 1.0+ (for PulseApollo target)