### PR TITLE
feat: add shake to present opt in

### DIFF
--- a/Sources/PulseUI/Features/ShakeToView.swift
+++ b/Sources/PulseUI/Features/ShakeToView.swift
@@ -1,0 +1,34 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020-2024 Alexander Grebenyuk (github.com/kean).
+
+import UIKit
+import SwiftUI
+
+#if os(iOS)
+
+extension UIViewController {
+    
+    open override func motionBegan(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
+        
+        if #available(iOS 16.0, *),
+           motion == .motionShake,
+           UserDefaults.standard.bool(forKey: ConsoleView.shakeToPresentIsEnableKey) {
+            
+            let logVC = UIHostingController(rootView: NavigationStack { ConsoleView() })
+            present(logVC, animated: true, completion: nil)
+        }
+        
+        next?.motionBegan(motion, with: event)
+    }
+}
+
+extension ConsoleView {
+    static let shakeToPresentIsEnableKey = "pulse-shake-to-present-is-enabled"
+    
+    public static func shakeToPresent(isEnabled: Bool) {
+        UserDefaults.standard.set(isEnabled, forKey: shakeToPresentIsEnableKey)
+    }
+}
+
+#endif


### PR DESCRIPTION
I recently updated from https://github.com/kasketis/netfox to Pulse. However one feature my BE colleagues missed was the shake gesture to view the network which is quite convenient to check what's going at any time.

I added it in my app, but thought this might be a neat opt in feature to have in Pulse directly!

Similar tools like Netfox or https://github.com/pmusolino/Wormholy also have this out of the box