### PR TITLE
Fix empty share content in RichTextView body screens

### DIFF
--- a/Sources/PulseUI/Features/FileViewer/RichTextView/RichTextView.swift
+++ b/Sources/PulseUI/Features/FileViewer/RichTextView/RichTextView.swift
@@ -79,7 +79,7 @@ public struct RichTextView: View {
         if !isTextViewBarItemsHidden {
             Menu(content: {
                 AttributedStringShareMenu(shareItems: $shareItems) {
-                    viewModel.textStorage
+                    viewModel.originalText
                 }
             }, label: {
                 Image(systemName: "square.and.arrow.up")


### PR DESCRIPTION
PulseUI: Fix empty Share output on Request/Response Body and Header detail screens

**Problem**
On network log detail screens, share actions were not reliably exporting content.
In particular, Request Body, Response Body, Request Headers, and Response Headers screens could produce empty output when using Share as Text, Share as HTML, or Share as PDF.

From the user perspective, this appeared as:

Empty content in the iOS share sheet preview
Copy action producing blank text
Note: Sharing from the top-level URL screen was working as expected. The issue was limited to nested detail screens.

**Root Cause**
The detail-screen share flow could resolve content from a source that was not stable at share time under certain view lifecycle conditions.
As a result, the share payload could be generated as empty even when visible content existed on screen.

**Solution**
Updated the share-content source to use a stable original content reference for detail screens.
This ensures Share as Text/HTML/PDF always receives valid content for Request/Response Body and Header views.

**Scope**
Request Body detail screen
Response Body detail screen
Request Headers detail screen
Response Headers detail screen
Share as Text
Share as HTML
Share as PDF
Test Plan
Open a network task from the console.
Verify URL-level share still works (regression check).
Open Request Body and run Share as Text, then Copy.
Open Response Body and run Share as Text, then Copy.
Open Request Headers and test Share as Text/HTML/PDF.
Open Response Headers and test Share as Text/HTML/PDF.
Paste copied content into Notes and verify non-empty output.
Repeat after app relaunch to confirm consistency.

**Expected Result**
All share actions from Request/Response Body and Header detail screens now export real content instead of empty output.