### PR TITLE
Recreate blobs directory after store schema migration

### DIFF
--- a/Sources/Pulse/LoggerStore/LoggerStore.swift
+++ b/Sources/Pulse/LoggerStore/LoggerStore.swift
@@ -172,6 +172,7 @@ public final class LoggerStore: @unchecked Sendable, Identifiable {
     private static func removePreviousStore(at storeURL: URL) throws {
         try Files.removeItem(at: storeURL)
         try Files.createDirectory(at: storeURL, withIntermediateDirectories: true)
+        Files.createDirectoryIfNeeded(at: storeURL.appending(directory: blobsDirectoryName))
     }
 
     private func postInitialization() throws {


### PR DESCRIPTION
## Problem

When `LoggerStore` is initialized against an existing store whose `manifest.json` version differs from `currentStoreVersion`, `removePreviousStore(at:)` is invoked to wipe the previous data. It removes `storeURL` entirely and recreates it as an empty directory — but **does not recreate the `blobs/` subdirectory**. The `blobs/` directory was created earlier in `init` (via `Files.createDirectoryIfNeeded(at: blobsURL)`), and after `removePreviousStore` it no longer exists for the rest of the session.

For every blob captured during this session whose compressed size exceeds `Configuration.inlineLimit` (16 KB by default — i.e. almost any real-world JSON response body), `storeBlob` falls through to:

```swift
try? processedData.write(to: makeBlobURL(for: key.hexString))
```

The write silently fails because the parent directory is missing. The `LoggerBlobHandleEntity` row is still saved (with `inlineData == nil`, no file on disk), and `responseBodySize` is populated on `NetworkTaskEntity`. The console then shows:

> **Unavailable**
> The response body was deleted from the store to reduce its size. Increase `responseBodySizeLimit` of the store.

The error message is misleading — `responseBodySizeLimit` had nothing to do with it; bumping it doesn't help.

## Reproduction

Empirical reproduction on iOS 26 simulator with a host app integrating Pulse:

1. Use Pulse 5.1.4 (`currentStoreVersion = 3.6.0`). Capture a network response > 16 KB compressed. Confirm a file exists at `current.pulse/blobs/<sha1>` matching the `ZLOGGERBLOBHANDLEENTITY.ZKEY` row.
2. Upgrade to Pulse 5.2.1 (`currentStoreVersion = 3.7.0`). Relaunch the app **without uninstalling** (so the old `manifest.json` is present). Make another large request. Observe:
   - `manifest.json` is now `version: \"3.7.0\"` (migration ran)
   - `blobs/` directory exists but is **empty**
   - `ZNETWORKTASKENTITY` has the task with non-zero `ZRESPONSEBODYSIZE` and a non-null `ZRESPONSEBODY` FK
   - The referenced `ZLOGGERBLOBHANDLEENTITY` row exists, but `ZINLINEDATA` is `NULL` and no file exists at `blobs/<hex(ZKEY)>`
3. PulseUI shows \"Unavailable\" for the response body.

Confirmed end-to-end on a real app upgrade path — this is what users will hit when bumping their dependency from 5.1.x to 5.2.x.

## Fix

Mirror the cleanup pattern already used by `_removeAll()` (`LoggerStore.swift:862-863`) and recreate the `blobs/` subdirectory at the end of `removePreviousStore`:

```swift
private static func removePreviousStore(at storeURL: URL) throws {
    try Files.removeItem(at: storeURL)
    try Files.createDirectory(at: storeURL, withIntermediateDirectories: true)
    Files.createDirectoryIfNeeded(at: storeURL.appending(directory: blobsDirectoryName))
}
```

After applying the fix, repeating step 2 of the reproduction produces a populated `blobs/<sha1>` file matching the entity row, and the response body renders correctly in PulseUI.

## Scope

One-line change. Affects only the migration path — fresh installs already work because the initial `Files.createDirectoryIfNeeded(at: blobsURL)` in `init` is never invalidated.