### PR TITLE
Speed up text search in NetworkInspector for large response bodies

### DIFF
--- a/Sources/PulseUI/Features/FileViewer/RichTextView/RichTextViewModel.swift
+++ b/Sources/PulseUI/Features/FileViewer/RichTextView/RichTextViewModel.swift
@@ -51,7 +51,7 @@ public final class RichTextViewModel: ObservableObject {
 
         Publishers.CombineLatest($searchTerm, $searchOptions)
             .dropFirst()
-            .receive(on: DispatchQueue.main) // Make sure self returns new values
+            .debounce(for: .milliseconds(200), scheduler: DispatchQueue.main)
             .sink { [weak self] _, _ in
                 self?.setSearchNeeded()
             }.store(in: &cancellables)
@@ -61,7 +61,7 @@ public final class RichTextViewModel: ObservableObject {
         guard let context = context else { return }
 
         // Not updated self.searchTerm because searchable doesn't like that
-        let matches = search(searchTerm: context.searchTerm.text, in: textStorage.string as NSString, options: context.searchTerm.options)
+        let matches = search(searchTerm: context.searchTerm.text, in: originalText, options: context.searchTerm.options)
         didUpdateMatches(matches, string: textStorage)
         if context.matchIndex < matches.count {
             DispatchQueue.main.async {
@@ -97,16 +97,17 @@ public final class RichTextViewModel: ObservableObject {
 
         let string = textStorage
         let (searchTerm, options) = (searchTerm, searchOptions)
+        let originalText = self.originalText
 
         queue.async {
-            let matches = search(searchTerm: searchTerm, in: string.string as NSString, options: options)
+            let matches = search(searchTerm: searchTerm, in: originalText, options: options)
             DispatchQueue.main.async {
                 self.didUpdateMatches(matches, string: string)
             }
         }
     }
 
-    private func didUpdateMatches(_ newMatches: [NSRange], string: NSAttributedString) {
+    private func didUpdateMatches(_ newMatches: [SearchMatch], string: NSAttributedString) {
         performUpdates { _ in
             clearMatches()
 
@@ -114,14 +115,7 @@ public final class RichTextViewModel: ObservableObject {
                 textStorage.setAttributedString(string)
             }
 
-            matches = newMatches.filter {
-                textStorage.attributes(at: $0.location, effectiveRange: nil)[.isTechnical] == nil
-            }.map {
-                let color = textStorage.attribute(.foregroundColor, at: $0.location, effectiveRange: nil) as? UXColor
-                let backgroundColor = textStorage.attribute(.backgroundColor, at: $0.location, effectiveRange: nil) as? UXColor
-
-                return SearchMatch(range: $0, originalForegroundColor: color ?? .label, originalBackgroundColor: backgroundColor)
-            }
+            matches = newMatches
 
             for match in matches {
                 highlight(range: match.range)
@@ -153,25 +147,20 @@ public final class RichTextViewModel: ObservableObject {
     private func didUpdateCurrentSelectedMatch(previousMatch: Int? = nil) {
         guard !matches.isEmpty else { return }
 
-        // Scroll to visible range
-        // Make sure it's somewhere in the middle (find newlines)
+        // Scroll to a slightly extended range so the match isn't pinned to the
+        // top edge. Use native newline search instead of a per-character loop.
         var range = matches[selectedMatchIndex].range
-        var index = range.upperBound
-        var newlines = 0
         let string = textStorage.string as NSString
-        while index < textStorage.length {
-            if let character = Character(string.character(at: index)), character.isNewline {
-                newlines += 1
-                range.length += index - range.upperBound
-                if newlines == 8 {
-                    break
-                }
-            }
-            index += 1
+        var searchStart = range.upperBound
+        for _ in 0..<8 {
+            guard searchStart < string.length else { break }
+            let found = string.range(of: "\n", options: [], range: NSRange(location: searchStart, length: string.length - searchStart))
+            if found.location == NSNotFound { break }
+            range.length = found.location - range.location
+            searchStart = found.upperBound
         }
-        if let textView = textView {
-            textView.scrollRangeToVisible(range)
-        }
+        textView?.scrollRangeToVisible(range)
+
         // Update highlights
         if let previousMatch = previousMatch {
             highlight(range: matches[previousMatch].range)
@@ -198,11 +187,26 @@ public final class RichTextViewModel: ObservableObject {
     }
 }
 
-private func search(searchTerm: String, in string: NSString, options: StringSearchOptions) -> [NSRange] {
+/// Runs on a background queue. We resolve match metadata (technical-attribute filter
+/// and the original colors used by `clearMatches`) from the immutable `originalText`
+/// here, so the main-thread work in `didUpdateMatches` is just applying highlights.
+private func search(searchTerm: String, in originalText: NSAttributedString, options: StringSearchOptions) -> [RichTextViewModel.SearchMatch] {
     guard searchTerm.count >= 1 else {
         return []
     }
-    return string.ranges(of: searchTerm, options: options)
+    let ranges = (originalText.string as NSString).ranges(of: searchTerm, options: options)
+    return ranges.compactMap { range -> RichTextViewModel.SearchMatch? in
+        guard range.location < originalText.length else { return nil }
+        let attributes = originalText.attributes(at: range.location, effectiveRange: nil)
+        guard attributes[.isTechnical] == nil else { return nil }
+        let foreground = attributes[.foregroundColor] as? UXColor
+        let background = attributes[.backgroundColor] as? UXColor
+        return RichTextViewModel.SearchMatch(
+            range: range,
+            originalForegroundColor: foreground ?? .label,
+            originalBackgroundColor: background
+        )
+    }
 }
 
 #endif

--- a/Sources/PulseUI/Features/FileViewer/RichTextView/RichTextViewModel.swift
+++ b/Sources/PulseUI/Features/FileViewer/RichTextView/RichTextViewModel.swift
@@ -65,7 +65,6 @@ public final class RichTextViewModel: ObservableObject {
         didUpdateMatches(matches, string: textStorage)
         if context.matchIndex < matches.count {
             DispatchQueue.main.async {
-                self.textView?.layoutManager.allowsNonContiguousLayout = false // Remove this workaround
                 UIView.performWithoutAnimation {
                     self.updateMatchIndex(context.matchIndex)
                 }


### PR DESCRIPTION
## Problem

Opening a large response (multi-MB JSON, tens of thousands of matches) in the NetworkInspector body viewer makes the search field essentially unusable: typing a query freezes the UI for seconds between keystrokes, and stepping to a far-away match stalls visibly.

Profiling pointed to four cooperating hot spots:

1. Every keystroke triggered a full search pass. `isSearchingInBackground` only serialized them, it didn't drop intermediate inputs.
2. Once ranges came back, `didUpdateMatches` (on the main thread) called `textStorage.attributes(at:)` twice per match to snapshot foreground / background colors before highlighting. With thousands of matches this blocked the run loop on its own.
3. `prepare()` was setting `layoutManager.allowsNonContiguousLayout = false`, forcing TextKit to build layout contiguously from the start of the document to the target range before `scrollRangeToVisible` could jump in. On a multi-MB string a deep jump means materializing layout for everything in between.
4. The "extend scroll range by 8 newlines" loop in `didUpdateCurrentSelectedMatch` walked the string one UTF-16 unit at a time with `Character` boxing.

## Changes

Two commits, both touching only `RichTextViewModel.swift`:

**1. Speed up text search in NetworkInspector for large response bodies**

- Debounce `searchTerm` / `searchOptions` updates by 200 ms.
- Build `SearchMatch` (technical-attribute filter + original color snapshots used by `clearMatches`) on the background queue against the immutable `originalText` instead of touching `textStorage` from the main thread.
- Replace the per-character newline scan with `NSString.range(of: "\n", options: [], range:)`.

**2. Remove forced contiguous layout when navigating to a search match**

Drop `layoutManager.allowsNonContiguousLayout = false` from `prepare()`. The line already carried a `// Remove this workaround` comment but no context about what it was working around. I don't know the original reason it was added — on large responses scrolling into a match feels visibly faster with no glitches observed (jumping to first / middle / last match, opening with a pre-filled search term via `TextViewSearchContext`). **If you remember a specific scenario where this was needed, happy to restore it or scope it more narrowly.** I kept it as a separate commit so it can be reverted on its own.

## Repro

1. Load a sizable JSON response into Pulse (a few MB is enough, I tested on ~5 MB / ~19k matches).
2. Open the response body, focus the search field.
3. Before: typing a multi-character query freezes the UI between keystrokes; jumping from the first to the last match stalls for several seconds.
4. After: typing stays responsive; far jumps feel instantaneous.

## Notes

- No public API change.
- The `usingTextLayoutManager: false` path in `WrappedTextView` (with its "extremely slow on iOS 16" note) is untouched. A TextKit 2 migration would let highlights live on the layout manager instead of mutating text storage, but it's a larger change and out of scope here.