### PR TITLE
Fix SIGTRAP in NetworkTaskEntity.state(in:) when session UUID is NULL

### DIFF
--- a/Sources/PulseUI/Helpers/FileViewModelContext.swift
+++ b/Sources/PulseUI/Helpers/FileViewModelContext.swift
@@ -49,8 +49,14 @@ extension NetworkTaskEntity {
     /// task is pending, but it's from the previous app run.
     package func state(in store: LoggerStoreProtocol?) -> NetworkTaskEntity.State? {
         let state = self.state
-        if state == .pending, let sessionID = store?.currentSessionID, self.session != sessionID {
-            return nil
+        if state == .pending, let sessionID = store?.currentSessionID {
+            // Read via KVC so a NULL stored value (allowed by Core Data because
+            // `session` is implicitly optional in the model) is surfaced as
+            // `nil` instead of trapping the ObjC->Swift UUID bridge.
+            let taskSession = value(forKey: "session") as? UUID
+            if taskSession != sessionID {
+                return nil
+            }
         }
         return state
     }


### PR DESCRIPTION
### Summary
Defensively reads `NetworkTaskEntity.session` via KVC in `state(in:)` so a `NULL` value in the underlying Core Data row no longer traps the implicit Obj-C → Swift `UUID` bridge.

### Crash signature
```
Fatal Exception: SIGTRAP
0  Swift     Swift.UUID._unconditionallyBridgeFromObjectiveC(...)
1  PulseUI   NetworkTaskEntity.state(in:) (FileViewModelContext.swift:52)
2  PulseUI   ConsoleFormatter.status(for:store:) (Formatters.swift:103)
3  PulseUI   ConsoleTaskCell.makeInfo(settings:) (ConsoleTaskCell.swift:100)
...
```

### Root cause
`NetworkTaskEntity.session` is declared as `@NSManaged public var session: UUID` (non-optional) in `LoggerStore+Entities.swift`, but the corresponding attribute in `LoggerStore+Model.swift` is created without explicitly setting `isOptional = false`:

```swift
Attribute("session", .UUIDAttributeType),
```

Per Core Data semantics, `NSAttributeDescription.isOptional` defaults to `true`, so the model permits `NULL` for `session`. Whenever a row ends up with a `NULL` session (e.g. data persisted under an older schema, or a row created before the column was populated and surviving lightweight migration), reading `self.session` from Swift goes through `UUID._unconditionallyBridgeFromObjectiveC(_:)`, which traps on `nil` → SIGTRAP.

The only read site for this property in PulseUI is `FileViewModelContext.swift:52`, hit transitively from `ConsoleFormatter.status(for:store:)` → `ConsoleTaskCell` while rendering the Console list.

### Fix
Read `session` via `value(forKey: "session") as? UUID` at the crash site. The semantics are preserved:
- For valid rows with a non-`nil` session, the comparison behaves exactly as before.
- For rows with a `NULL` session, the cast yields `nil`, the comparison `nil != sessionID` is `true`, and the function returns `nil` — which matches the existing doc comment ("returns nil if the task is an unknown state … from the previous app run").

### Why not change the Swift property to `UUID?`
That would be a breaking public-API change for every consumer reading the property. The defensive KVC read is the smallest change that prevents the trap at the only known crash site.

### Why not change the model to `isOptional = false`
Stores persisted under the current schema could already contain `NULL` rows. Forcing the attribute to non-optional via lightweight migration would either fail or require a custom migration policy, which is out of scope for a bug fix.

### Test plan
- Verified the affected callsite is the only `entity.session` read in PulseUI (`ConsoleDataSource.swift` references to `.session` are unrelated enum cases / formatters).
- Built `PulseUI` against the existing scheme; no API surface changes.
