### PR TITLE
fix: RichTextView share/copy produces empty content when textView is nil

### DIFF
--- a/Sources/PulseUI/Features/FileViewer/RichTextView/RichTextViewModel.swift
+++ b/Sources/PulseUI/Features/FileViewer/RichTextView/RichTextViewModel.swift
@@ -27,7 +27,7 @@ public final class RichTextViewModel: ObservableObject {
     public var isEmpty: Bool { originalText.length == 0 }
 
     weak var textView: UXTextView? // Not proper MVVM
-    var textStorage: NSTextStorage { textView?.textStorage ?? NSTextStorage(string: "") }
+    var textStorage: NSTextStorage { textView?.textStorage ?? NSTextStorage(attributedString: originalText) }
 
     private var isSearchingInBackground = false
     private var isSearchNeeded = false


### PR DESCRIPTION
### Problem:

When using Pulse inside a UIKit app (via UIHostingController), tapping the share button on a detail page (response body, request body, headers etc.) and selecting "Copy as Text", "Copy as HTML", or "Copy as PDF" copies empty content to the clipboard.

The root cause is in RichTextViewModel.textStorage:

```
// Current
var textStorage: NSTextStorage { textView?.textStorage ?? NSTextStorage(string: "") }
```
textView is a weak var set by WrappedTextView (a UIViewRepresentable). In UIKit-hosted environments, SwiftUI's view lifecycle differs from a pure SwiftUI app — textView can be nil at the moment the share button closure executes. When that happens, textStorage returns an empty NSTextStorage, resulting in empty clipboard content.

This does not reproduce in pure SwiftUI apps because the view lifecycle keeps textView alive consistently.

### Fix:

Fall back to originalText instead of an empty string when textView is nil:

```
// Fixed
var textStorage: NSTextStorage { textView?.textStorage ?? NSTextStorage(attributedString: originalText) }
```
originalText is always populated — it holds the fully rendered attributed string set during initialization. This ensures share/copy always produces the correct content regardless of textView's lifecycle state.