### PR TITLE
fix: use opaque graphics context when resizing the app icon

### DIFF
--- a/Sources/Pulse/Helpers/ImageProcessor.swift
+++ b/Sources/Pulse/Helpers/ImageProcessor.swift
@@ -19,9 +19,9 @@ import ImageIO
 #endif
 
 enum Graphics {
-    static func resize(_ image: PlatformImage, to size: CGSize) -> PlatformImage? {
+    static func resize(_ image: PlatformImage, to size: CGSize, opaque: Bool = false) -> PlatformImage? {
 #if canImport(UIKit)
-        UIGraphicsBeginImageContextWithOptions(size, false, 1.0)
+        UIGraphicsBeginImageContextWithOptions(size, opaque, 1.0)
         image.draw(in: CGRect(x: 0, y: 0, width: size.width, height: size.height))
         let thumbnail = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()

--- a/Sources/Pulse/LoggerStore/LoggerStore+Info.swift
+++ b/Sources/Pulse/LoggerStore/LoggerStore+Info.swift
@@ -97,7 +97,10 @@ private func getAppIcon() -> Data? {
           // On iOS 26+, `UIImage(named:)` can raise `NSInternalInconsistencyException`
           // ("Need an imageRef") for assets that can't be rasterized for the current trait.
           let image = PulseObjCExceptionCatcher.attempt({ PlatformImage(named: lastIcon) }),
-          let thumbnail = Graphics.resize(image, to: CGSize(width: 44, height: 44)) else { return nil }
+          // App icons are always opaque per Apple's icon guidelines; resizing into a
+          // non-opaque context preserves an alpha channel that HEIF encoding will then
+          // warn about ("trying to save an opaque image with AlphaLast").
+          let thumbnail = Graphics.resize(image, to: CGSize(width: 44, height: 44), opaque: true) else { return nil }
     return Graphics.encode(thumbnail, compressionQuality: 0.9)
 }
 


### PR DESCRIPTION
## Why

Fixes #362.

\`Graphics.resize\` always opened the UIKit image context with \`opaque: false\`, so even resizes of guaranteed-opaque inputs kept an alpha channel. \`getAppIcon()\` then ran the resized 44×44 result through HEIF encoding, which logs the now-familiar:

\`\`\`
writeImageAtIndex:1094: ⭕️ ERROR: 'MyApp' is trying to save an opaque image (44x44)
with 'AlphaLast'. This would unnecessarily increase the file size and will double
(!!!) the required memory when decoding the image --> ignoring alpha.
\`\`\`

## What

- Adds an \`opaque: Bool = false\` parameter to \`Graphics.resize\` so existing call sites compile unchanged.
- \`getAppIcon()\` now passes \`opaque: true\` (Apple's icon guidelines guarantee app icons are opaque).

Two small files, source-compatible.

## Scope

Picked the param-with-default approach over hardcoding \`opaque\` to \`true\` inside \`resize\` since the function is non-private and a future caller may legitimately need an alpha channel. If you'd prefer the hardcoded variant, happy to switch.